### PR TITLE
add renewal_triggered_by parameter to payment.set_renew_token

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,9 +6,12 @@ History
 Unreleased
 **********
 * fix backward compatibility by making PayuProvider's get_refund_description argument optional
+* add `renewal_triggered_by` parameter to `payment.set_renew_token`
 * make PayuProvider.refund fail if get_refund_description is not provided
 * make PayuProvider.refund raise PayuApiError if an unexpected response is received
 * deprecate the default value of get_refund_description; set it to a callable instead
+* deprecate `automatic_renewal` parameter of `payment.set_renew_token`; use `renewal_triggered_by` parameter instead
+* deprecate `None` value of `renewal_triggered_by` parameter of `payment.set_renew_token`; set `"user"`/`"task"`/`"other"` instead
 
 1.3.1 (2024-03-19)
 ******************

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -441,7 +441,7 @@ class PayuProvider(BasicProvider):
                     card_masked_number=response_dict["payMethods"]["payMethod"]["card"][
                         "number"
                     ],
-                    automatic_renewal=self.recurring_payments,
+                    renewal_triggered_by="task" if self.recurring_payments else "user",
                 )
             add_extra_data(payment, {"card_response": response_dict})
 

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -34,6 +34,8 @@ class JSONEquals(str):
 
 
 class Payment(Mock):
+    UNSET = object()
+
     id = 1
     description = "payment"
     currency = "USD"
@@ -98,13 +100,15 @@ class Payment(Mock):
         card_expire_year=None,
         card_expire_month=None,
         card_masked_number=None,
-        automatic_renewal=None,
+        automatic_renewal=UNSET,
+        renewal_triggered_by=UNSET,
     ):
         self.token = token
         self.card_expire_year = card_expire_year
         self.card_expire_month = card_expire_month
         self.card_masked_number = card_masked_number
         self.automatic_renewal = automatic_renewal
+        self.renewal_triggered_by = renewal_triggered_by
 
 
 class TestPayuProvider(TestCase):
@@ -188,7 +192,8 @@ class TestPayuProvider(TestCase):
             self.assertEqual(self.payment.card_expire_year, 2021)
             self.assertEqual(self.payment.card_expire_month, 1)
             self.assertEqual(self.payment.card_masked_number, "1234xxx")
-            self.assertEqual(self.payment.automatic_renewal, True)
+            self.assertEqual(self.payment.automatic_renewal, Payment.UNSET)
+            self.assertEqual(self.payment.renewal_triggered_by, "task")
 
     def test_redirect_payu_unknown_status(self):
         self.set_up_provider(


### PR DESCRIPTION
Enables migration to https://github.com/django-getpaid/django-plans/pull/188