### PR TITLE
change extra_data with atomic operations to reduce concurrent problems

### DIFF
--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -43,16 +43,23 @@ CENTS = Decimal("0.01")
 
 
 def add_extra_data(payment, new_extra_data):
+    payment.refresh_from_db(fields=["extra_data"])
     if payment.extra_data:
         old_extra_data = json.loads(payment.extra_data)
     else:
         old_extra_data = {}
     extra_data = {**old_extra_data, **new_extra_data}
     payment.extra_data = json.dumps(extra_data, indent=2)
-    payment.save()
+    payment_change_reason_original = payment._change_reason
+    payment._change_reason = (
+        "PayU Payments: add_new_status"  # For django-simple-history
+    )
+    payment.save(update_fields=["extra_data"])
+    payment._change_reason = payment_change_reason_original
 
 
 def add_new_status(payment, new_status):
+    payment.refresh_from_db(fields=["extra_data"])
     if payment.extra_data:
         old_extra_data = json.loads(payment.extra_data)
     else:
@@ -61,7 +68,12 @@ def add_new_status(payment, new_status):
         old_extra_data["statuses"] = []
     old_extra_data["statuses"].append(new_status)
     payment.extra_data = json.dumps(old_extra_data, indent=2)
-    payment.save()
+    payment_change_reason_original = payment._change_reason
+    payment._change_reason = (
+        "PayU Payments: add_new_status"  # For django-simple-history
+    )
+    payment.save(update_fields=["extra_data"])
+    payment._change_reason = payment_change_reason_original
 
 
 def quantize_price(price, currency):
@@ -424,6 +436,9 @@ class PayuProvider(BasicProvider):
 
         try:
             payment.transaction_id = response_dict["orderId"]
+            payment._change_reason = "PayU Payments: create_order -> transaction_id"  # For django-simple-history
+            payment.save(update_fields=["transaction_id"])
+            payment._change_reason = None
 
             if "payMethods" in response_dict:
                 payment.set_renew_token(
@@ -443,8 +458,6 @@ class PayuProvider(BasicProvider):
 
             if response_dict["status"]["statusCode"] == "SUCCESS":
                 if "redirectUri" in response_dict:
-                    payment.pay_link = response_dict["redirectUri"]
-                    payment.save()
                     return response_dict["redirectUri"]
                 else:
                     if auto_renew:
@@ -573,7 +586,13 @@ class PayuProvider(BasicProvider):
                             payment.change_status(PaymentStatus.REFUNDED)
                         else:
                             payment.captured_amount -= refunded_price
-                            payment.save()
+                            payment_change_reason_original = payment._change_reason
+                            # Change history for django-simple-history
+                            payment._change_reason = (
+                                "PayU Payments: process_notification -> refund"
+                            )
+                            payment.save(update_fields=["captured_amount", "message"])
+                            payment._change_reason = payment_change_reason_original
                         return HttpResponse("ok", status=200)
                     else:
                         raise Exception("Refund was not finelized", data)
@@ -594,9 +613,13 @@ class PayuProvider(BasicProvider):
                             data["order"]["totalAmount"],
                             data["order"]["currencyCode"],
                         )
-                        type(payment).objects.filter(pk=payment.pk).update(
-                            captured_amount=payment.captured_amount
+                        payment_change_reason_original = payment._change_reason
+                        # Change history for django-simple-history
+                        payment._change_reason = (
+                            "PayU Payments: process_notification -> confirmed"
                         )
+                        payment.save(update_fields=["captured_amount"])
+                        payment._change_reason = payment_change_reason_original
                     if (
                         payment.status == PaymentStatus.CONFIRMED
                         and payment.status != status
@@ -663,7 +686,9 @@ class PayuProvider(BasicProvider):
         )
         payment_extra_data_refund_responses.append(response)
         payment.extra_data = json.dumps(payment_extra_data, indent=2)
+        payment._change_reason = "PayU Payments: refund"  # For django-simple-history
         payment.save()
+        payment._change_reason = None
 
         try:
             refund = response["refund"]

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -184,11 +184,14 @@ class Payment(Mock):
             **{field: getattr(self, field) for field in update_fields}
         )
 
-    def refresh_from_db(self, *args, **kwargs):
+    def refresh_from_db(self, *args, fields=None, **kwargs):
         if args or kwargs:
             raise NotImplementedError(f"arguments not supported yet: {args}, {kwargs}")
         payment_from_db = Payment.objects.get(pk=self.pk)
-        for field in self._meta.get_fields(include_parents=True, include_hidden=True):
+        refresh_fields = self._meta.get_fields(include_parents=True, include_hidden=True)
+        if fields is not None:
+            refresh_fields = [field for field in refresh_fields if field.name in fields]
+        for field in refresh_fields:
             field_value_from_db = getattr(payment_from_db, field.name)
             setattr(self, field.name, field_value_from_db)
 


### PR DESCRIPTION
Pokus o opravu https://github.com/BlenderKit/BlenderKit-server/issues/951

- [ ] Je potřeba zkontrolovat, jestli se opravdu všechno správně uloží, jestli nebylo počítáno, že se něco uloží implicitně
- [ ] Zatím to rozdrobuje historii změn - otázka, jestli je to dobře