### PR TITLE
Add Google Pay button to the express payment form

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ unreleased
 * create_order: don't overwrite the stored renew token when the order
   response echoes a pay method without card data (e.g. a wallet pay-by-link
   method), which is not a reusable card token.
+* fix HtmlOutputField rendering its html autoescaped on Django 5.x - the
+  "This payment is already being processed" error form showed literal
+  "<br/><strong>..." markup to the user.
 
 2.1.1 (2026-05-07)
 ******************

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,18 @@
 
 History
 -------
+unreleased
+**********
+* add optional Google Pay button to the express payment form (``google_pay``
+  provider parameter). The Google Pay token is charged through a standard
+  PayU order (pay-by-link method ``ap`` with base64 ``authorizationCode``);
+  with ``recurring_payments=True`` the first order is sent with
+  ``recurring=FIRST`` and the returned multi-use card token is stored for
+  server-initiated renewals.
+* create_order: don't overwrite the stored renew token when the order
+  response echoes a pay method without card data (e.g. a wallet pay-by-link
+  method), which is not a reusable card token.
+
 2.1.1 (2026-05-07)
 ******************
 * fix create_order demoting an already CONFIRMED payment to ERROR when PayU

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Here are valid parameters for the provider:
 **Google Pay**:
    With ``express_payments=True`` the provider can render a Google Pay button above the PayU card widget. The button uses the `Google Pay API <https://developers.google.com/pay/api/web/overview>`_ with PayU as the gateway (``gateway: payu``); the returned token is charged through the standard PayU order with an ``ap`` pay-by-link method. With ``recurring_payments=True`` the first Google Pay order is sent with ``recurring=FIRST`` so PayU issues a multi-use card token that is stored via ``Payment.set_renew_token()`` and used for later server-initiated renewals exactly like card payments.
 
-   NOTE: Google Pay needs to be enabled on your PayU POS. For the production environment you also need a merchant ID from the `Google Pay & Wallet Console <https://pay.google.com/business/console>`_.
+   NOTE: Google Pay needs to be enabled on your PayU POS. For the production environment you also need a merchant ID from the `Google Pay & Wallet Console <https://pay.google.com/business/console>`_. If your site sends a Content-Security-Policy, allow the Google Pay script (``script-src https://pay.google.com``, frames from ``https://pay.google.com``).
 
    Valid keys of the ``google_pay`` dict:
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ Here are valid parameters for the provider:
    :express_payments:       use PayU express form
    :widget_branding:        tell express form to show PayU branding
    :store_card:             (default: False) whether PayU should store the card
+   :google_pay:             (default: None) a dict that enables a Google Pay button next to the express form, only valid with ``express_payments=True``, see below
    :get_refund_description: An optional callable that is called with two keyword arguments `payment` and `amount` in order to get the string description of the particular refund whenever ``provider.refund(payment, amount)`` is called. The callable is optional because of backwards compatibility. However, if it is not set, an attempt to refund raises an exception. A default value of `get_refund_description` is deprecated.
    :get_refund_ext_id:      An optional callable that is called with two keyword arguments `payment` and `amount` in order to get the External string refund ID of the particular refund whenever ``provider.refund(payment, amount)`` is called. If ``None`` is returned, no External refund ID is set. An External refund ID is not necessary if partial refunds won't be performed more than once per second. Otherwise, a unique ID is recommended since `PayuProvider.refund` is idempotent and if exactly same data will be provided, it will return the result of the already previously performed refund instead of performing a new refund. Defaults to a random UUID version 4 in the standard form.
    :get_buyer_language:     An optional callable that is called with with the keyword argument `payment` in order to get the language for the hosted payment page and e-mail messages sent from PayU to the payer. Consult `the documentation <https://developers.payu.com/europe/docs/get-started/integration-overview/references/#languages>`_ for an up-to-date list of supported language codes and their capabilities. When not set, a default value of ``en`` will be used.
@@ -66,6 +67,33 @@ Here are valid parameters for the provider:
 
    NOTE: notifications about the payment status from PayU are requested to be sent to `django-payments` `process_payment` url. The request from PayU can fail for several reasons (i.e. it can be blocked by proxy). Use "Show reports" page in PayU administration to get more information about the requests.
 
+
+**Google Pay**:
+   With ``express_payments=True`` the provider can render a Google Pay button above the PayU card widget. The button uses the `Google Pay API <https://developers.google.com/pay/api/web/overview>`_ with PayU as the gateway (``gateway: payu``); the returned token is charged through the standard PayU order with an ``ap`` pay-by-link method. With ``recurring_payments=True`` the first Google Pay order is sent with ``recurring=FIRST`` so PayU issues a multi-use card token that is stored via ``Payment.set_renew_token()`` and used for later server-initiated renewals exactly like card payments.
+
+   NOTE: Google Pay needs to be enabled on your PayU POS. For the production environment you also need a merchant ID from the `Google Pay & Wallet Console <https://pay.google.com/business/console>`_.
+
+   Valid keys of the ``google_pay`` dict:
+
+   :merchant_id:            Google Pay merchant ID (required for the production environment)
+   :merchant_name:          (optional) merchant name shown in the Google Pay sheet
+   :environment:            (default: ``"TEST"`` if ``sandbox`` else ``"PRODUCTION"``) Google Pay environment
+   :gateway_merchant_id:    (default: ``pos_id``) gateway merchant ID passed to the Google Pay tokenization specification
+   :allowed_auth_methods:   (default: ``["PAN_ONLY", "CRYPTOGRAM_3DS"]``)
+   :allowed_card_networks:  (default: ``["MASTERCARD", "VISA"]``)
+
+Example::
+
+      PAYMENT_VARIANTS = {
+          'payu': ('payments_payu.provider.PayuProvider', {
+              # ...
+              'express_payments': True,
+              'google_pay': {
+                  'merchant_id': 'BCR2DN4T26O5PZZZ',
+                  'merchant_name': 'My shop',
+              },
+          }),
+      }
 
 **Recurring payments**:
    If recurring payments are enabled, the PayU card token needs to be stored in your application for usage in next payments. The next payments can be either initiated by user through (user will be prompted only for payment confirmation by the express form) or by server.

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -12,6 +12,7 @@ import requests
 from django import forms
 from django.http.response import HttpResponse, HttpResponseRedirect
 from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 from payments import FraudStatus, PaymentStatus, RedirectNeeded
 from payments.core import BasicProvider, get_base_url
 from payments.forms import PaymentForm
@@ -175,12 +176,18 @@ class WidgetPaymentForm(PaymentForm):
         self, payu_base_url, script_params={}, google_pay_html="", *args, **kwargs
     ):
         ret = super(WidgetPaymentForm, self).__init__(*args, **kwargs)
-        form_html = google_pay_html + format_html(
-            "<script "
-            f"src='{payu_base_url}front/widget/js/payu-bootstrap.js' "
-            "pay-button='#pay-button' {params} >"
-            "</script>"
-            """
+        # mark_safe: plain-str concatenation would demote format_html's
+        # SafeString and get the whole widget HTML escaped when rendered.
+        # google_pay_html is server-built (no user input, see
+        # PayuProvider.get_google_pay_html).
+        form_html = mark_safe(
+            google_pay_html
+            + format_html(
+                "<script "
+                f"src='{payu_base_url}front/widget/js/payu-bootstrap.js' "
+                "pay-button='#pay-button' {params} >"
+                "</script>"
+                """
             <script>
                 function cardSuccess($data) {{
                     console.log('callback');
@@ -199,17 +206,18 @@ class WidgetPaymentForm(PaymentForm):
             </script>
             <div id="payu-widget"></div>
             """,
-            params=format_html_join(
-                " ", "{}='{}'", ((k, v) for k, v in script_params.items())
-            ),
-            process_url=urljoin(
-                get_base_url(),
-                self.payment.get_process_url(),
-            ),
-            success_url=urljoin(
-                get_base_url(),
-                self.payment.get_success_url(),
-            ),
+                params=format_html_join(
+                    " ", "{}='{}'", ((k, v) for k, v in script_params.items())
+                ),
+                process_url=urljoin(
+                    get_base_url(),
+                    self.payment.get_process_url(),
+                ),
+                success_url=urljoin(
+                    get_base_url(),
+                    self.payment.get_success_url(),
+                ),
+            )
         )
         self.fields["script"].widget = HtmlOutputField(html=form_html)
         return ret

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -165,7 +165,10 @@ class HtmlOutputField(forms.HiddenInput):
         return super(HtmlOutputField, self).__init__(*args, **kwargs)
 
     def render(self, *args, **kwargs):
-        return self.html
+        # mark_safe: a plain str gets autoescaped when the widget is rendered
+        # in a template (visible as literal "<br/><strong>..." on Django 5.x).
+        # The html is built by this module from trusted, server-side values.
+        return mark_safe(self.html)
 
 
 class WidgetPaymentForm(PaymentForm):

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -1,9 +1,11 @@
+import base64
 import hashlib
 import json
 import logging
 import uuid
 import warnings
 from decimal import ROUND_HALF_UP, Decimal
+from string import Template
 from urllib.parse import urljoin
 
 import requests
@@ -40,6 +42,75 @@ CURRENCY_SUB_UNIT = {
 
 
 CENTS = Decimal("0.01")
+
+GOOGLE_PAY_ALLOWED_AUTH_METHODS = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+GOOGLE_PAY_ALLOWED_CARD_NETWORKS = ["MASTERCARD", "VISA"]
+
+# Rendered with string.Template ($config, $process_url) because the JS is full
+# of braces that format_html would treat as placeholders.
+GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
+<div id="google-pay-button"></div>
+<script>
+(function() {
+    var cfg = $config;
+    var cardPaymentMethod = {
+        type: 'CARD',
+        parameters: {
+            allowedAuthMethods: cfg.allowed_auth_methods,
+            allowedCardNetworks: cfg.allowed_card_networks
+        },
+        tokenizationSpecification: {
+            type: 'PAYMENT_GATEWAY',
+            parameters: {
+                gateway: 'payu',
+                gatewayMerchantId: cfg.gateway_merchant_id
+            }
+        }
+    };
+    window.onGooglePayLoaded = function() {
+        var client = new google.payments.api.PaymentsClient({environment: cfg.environment});
+        client.isReadyToPay({
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            allowedPaymentMethods: [cardPaymentMethod]
+        }).then(function(response) {
+            if (!response.result) {
+                return;
+            }
+            var button = client.createButton({onClick: function() {
+                client.loadPaymentData({
+                    apiVersion: 2,
+                    apiVersionMinor: 0,
+                    allowedPaymentMethods: [cardPaymentMethod],
+                    transactionInfo: {
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: cfg.total,
+                        currencyCode: cfg.currency
+                    },
+                    merchantInfo: cfg.merchant_info
+                }).then(function(paymentData) {
+                    var body = new URLSearchParams();
+                    body.append('google_pay_token', paymentData.paymentMethodData.tokenizationData.token);
+                    return fetch('$process_url', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                        body: body.toString()
+                    }).then(function(response) {
+                        return response.text();
+                    }).then(function(url) {
+                        window.location.href = url;
+                    });
+                }).catch(function(err) {
+                    console.log('Google Pay payment did not complete', err);
+                });
+            }});
+            document.getElementById('google-pay-button').appendChild(button);
+        });
+    };
+})();
+</script>
+<script src="https://pay.google.com/gp/p/js/pay.js" async onload="onGooglePayLoaded()"></script>
+""")
 
 
 def add_extra_data(payment, new_extra_data):
@@ -100,9 +171,11 @@ class WidgetPaymentForm(PaymentForm):
     hide_submit_button = True  # For easy use in templates
     script = forms.CharField(label="Script")
 
-    def __init__(self, payu_base_url, script_params={}, *args, **kwargs):
+    def __init__(
+        self, payu_base_url, script_params={}, google_pay_html="", *args, **kwargs
+    ):
         ret = super(WidgetPaymentForm, self).__init__(*args, **kwargs)
-        form_html = format_html(
+        form_html = google_pay_html + format_html(
             "<script "
             f"src='{payu_base_url}front/widget/js/payu-bootstrap.js' "
             "pay-button='#pay-button' {params} >"
@@ -213,6 +286,10 @@ class PayuProvider(BasicProvider):
         self.card_on_file = kwargs.pop("card_on_file", False)
 
         self.express_payments = kwargs.pop("express_payments", False)
+        # Google Pay express button, only valid with express_payments=True.
+        # A dict with optional keys: merchant_id, merchant_name, environment,
+        # gateway_merchant_id, allowed_auth_methods, allowed_card_networks.
+        self.google_pay = kwargs.pop("google_pay", None)
         self.retry_count = 5
 
         self.pos_id = kwargs.pop("pos_id")
@@ -299,8 +376,40 @@ class PayuProvider(BasicProvider):
             payu_base_url=self.payu_base_url,
             data=data,
             script_params=payu_data,
+            google_pay_html=self.get_google_pay_html(payment) if not cvv_url else "",
             provider=self,
             payment=payment,
+        )
+
+    def get_google_pay_html(self, payment):
+        """Render the Google Pay button + JS for the express payment form."""
+        if not self.google_pay:
+            return ""
+        merchant_info = {}
+        if self.google_pay.get("merchant_name"):
+            merchant_info["merchantName"] = self.google_pay["merchant_name"]
+        if self.google_pay.get("merchant_id"):
+            merchant_info["merchantId"] = self.google_pay["merchant_id"]
+        config = {
+            "environment": self.google_pay.get(
+                "environment", "TEST" if self.payu_sandbox else "PRODUCTION"
+            ),
+            "gateway_merchant_id": str(
+                self.google_pay.get("gateway_merchant_id", self.pos_id)
+            ),
+            "allowed_auth_methods": self.google_pay.get(
+                "allowed_auth_methods", GOOGLE_PAY_ALLOWED_AUTH_METHODS
+            ),
+            "allowed_card_networks": self.google_pay.get(
+                "allowed_card_networks", GOOGLE_PAY_ALLOWED_CARD_NETWORKS
+            ),
+            "total": str(payment.total.quantize(CENTS)),
+            "currency": payment.currency,
+            "merchant_info": merchant_info,
+        }
+        return GOOGLE_PAY_SCRIPT_TEMPLATE.substitute(
+            config=json.dumps(config),
+            process_url=urljoin(get_base_url(), payment.get_process_url()),
         )
 
     def get_processor(self, payment):
@@ -345,6 +454,29 @@ class PayuProvider(BasicProvider):
         data = self.process_widget(payment, card_token, recurring)
         if recurring == "STANDARD":
             return HttpResponseRedirect(data)
+        return HttpResponse(data, status=200)
+
+    def process_google_pay_callback(self, payment, google_pay_token):
+        """Charge an order with a Google Pay token from the express form.
+
+        PayU expects the raw Google Pay token base64-encoded in the
+        authorizationCode of an "ap" pay-by-link method. The first payment of
+        a recurring plan is sent with recurring=FIRST so PayU issues a
+        multi-use card token for later renewals.
+        """
+        processor = self.get_processor(payment)
+        if self.card_on_file:
+            processor.cardOnFile = "FIRST"
+        elif self.recurring_payments:
+            processor.recurring = "FIRST"
+        processor.set_paymethod(
+            method_type="PBL",
+            value="ap",
+            authorization_code=base64.b64encode(
+                google_pay_token.encode("utf-8")
+            ).decode("ascii"),
+        )
+        data = self.create_order(payment, processor)
         return HttpResponse(data, status=200)
 
     def post_request(self, url, *args, **kwargs):
@@ -445,19 +577,20 @@ class PayuProvider(BasicProvider):
             payment._change_reason = None
 
             if "payMethods" in response_dict:
-                payment.set_renew_token(
-                    response_dict["payMethods"]["payMethod"]["value"],
-                    card_expire_year=response_dict["payMethods"]["payMethod"]["card"][
-                        "expirationYear"
-                    ],
-                    card_expire_month=response_dict["payMethods"]["payMethod"]["card"][
-                        "expirationMonth"
-                    ],
-                    card_masked_number=response_dict["payMethods"]["payMethod"]["card"][
-                        "number"
-                    ],
-                    renewal_triggered_by="task" if self.recurring_payments else "user",
-                )
+                pay_method = response_dict["payMethods"]["payMethod"]
+                # A wallet order (Google Pay) can echo the pay-by-link method
+                # ("ap") without card data; that value is not a reusable card
+                # token, so don't overwrite the stored renew token with it.
+                if "card" in pay_method:
+                    payment.set_renew_token(
+                        pay_method["value"],
+                        card_expire_year=pay_method["card"]["expirationYear"],
+                        card_expire_month=pay_method["card"]["expirationMonth"],
+                        card_masked_number=pay_method["card"]["number"],
+                        renewal_triggered_by=(
+                            "task" if self.recurring_payments else "user"
+                        ),
+                    )
             add_extra_data(payment, {"card_response": response_dict})
 
             if response_dict["status"]["statusCode"] == "SUCCESS":
@@ -654,6 +787,10 @@ class PayuProvider(BasicProvider):
 
         if "application/json" in request.META.get("CONTENT_TYPE", {}):
             return self.process_notification(payment, request)
+        elif "google_pay_token" in request.POST:
+            return self.process_google_pay_callback(
+                payment, request.POST["google_pay_token"]
+            )
         elif renew_token and self.recurring_payments:
             return self.process_widget_callback(
                 payment, renew_token, recurring="STANDARD"
@@ -806,11 +943,13 @@ class PaymentProcessor(object):
             }
             yield item
 
-    def set_paymethod(self, value, method_type="PBL"):
+    def set_paymethod(self, value, method_type="PBL", authorization_code=None):
         "Set payment method, can given by PayuApi.get_paymethod_tokens()"
         if not hasattr(self, "paymethods"):
             self.paymethods = {}
             self.paymethods["payMethod"] = {"type": method_type, "value": value}
+            if authorization_code:
+                self.paymethods["payMethod"]["authorizationCode"] = authorization_code
 
     def set_buyer_data(self, first_name, last_name, email, phone, lang_code):
         "Set buyer data"

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -50,7 +50,7 @@ GOOGLE_PAY_ALLOWED_CARD_NETWORKS = ["MASTERCARD", "VISA"]
 # Rendered with string.Template ($config, $process_url) because the JS is full
 # of braces that format_html would treat as placeholders.
 GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
-<div id="google-pay-button"></div>
+<div id="google-pay-button" class="payu-google-pay-button"></div>
 <script>
 (function() {
     var cfg = $config;
@@ -78,7 +78,8 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
             if (!response.result) {
                 return;
             }
-            var button = client.createButton({onClick: function() {
+            var container = document.getElementById('google-pay-button');
+            var button = client.createButton({buttonSizeMode: 'fill', onClick: function() {
                 client.loadPaymentData({
                     apiVersion: 2,
                     apiVersionMinor: 0,
@@ -90,6 +91,8 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
                     },
                     merchantInfo: cfg.merchant_info
                 }).then(function(paymentData) {
+                    container.classList.add('payu-wallet-processing');
+                    document.body.classList.add('payu-wallet-processing');
                     var body = new URLSearchParams();
                     body.append('google_pay_token', paymentData.paymentMethodData.tokenizationData.token);
                     return fetch('$process_url', {
@@ -102,10 +105,12 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
                         window.location.href = url;
                     });
                 }).catch(function(err) {
+                    container.classList.remove('payu-wallet-processing');
+                    document.body.classList.remove('payu-wallet-processing');
                     console.log('Google Pay payment did not complete', err);
                 });
             }});
-            document.getElementById('google-pay-button').appendChild(button);
+            container.appendChild(button);
         });
     };
 })();

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -424,7 +424,10 @@ class PayuProvider(BasicProvider):
             "merchant_info": merchant_info,
         }
         return GOOGLE_PAY_SCRIPT_TEMPLATE.substitute(
-            config=json.dumps(config),
+            # All config values come from provider settings, but escape "<"
+            # anyway so no value can ever break out of the <script> block
+            # (same hardening as Django's json_script).
+            config=json.dumps(config).replace("<", "\\u003c"),
             process_url=urljoin(get_base_url(), payment.get_process_url()),
         )
 

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -727,6 +727,26 @@ class TestPayuProvider(TestCase):
             self.assertIn("</script>", rendered_html)  # Test, that escaping works correctly
             self.assertIn("customer-language='cs'", rendered_html)
 
+    def test_payment_error_form_html_not_escaped(self):
+        """Test that the payment error form renders its html unescaped.
+
+        HtmlOutputField.render must return a safe string: a plain str gets
+        autoescaped when the form is rendered in a template on Django 5.x,
+        showing literal "<br/><strong>..." to the user.
+        """
+        from django.utils.safestring import SafeString
+
+        from payments_payu.provider import PaymentErrorForm
+
+        form = PaymentErrorForm()
+        rendered_widget = form.fields["script"].widget.render("script", None)
+        self.assertIsInstance(rendered_widget, SafeString)
+
+        template = Template("{{form.as_p}}")
+        rendered_html = template.render(Context({"form": form}))
+        self.assertIn("<strong>This payment is already being processed.", rendered_html)
+        self.assertNotIn("&lt;strong&gt;", rendered_html)
+
     def test_redirect_3ds_form(self):
         """Test redirection to 3DS page if requested by PayU"""
         self.set_up_provider(

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import base64
 import contextlib
 import json
 import warnings
@@ -830,6 +831,269 @@ class TestPayuProvider(TestCase):
         )
         self.assertEqual(self.payment.status, PaymentStatus.WAITING)
         self.assertEqual(self.payment.captured_amount, Decimal("0"))
+        self.assertNotIn(
+            "google-pay-button", form.fields["script"].widget.render("a", "b")
+        )
+
+    def test_payu_widget_form_google_pay(self):
+        """Test that the Google Pay button is rendered in the express form"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={
+                "merchant_id": "test_merchant_id",
+                "merchant_name": "Test shop",
+            },
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        self.assertEqual(form.__class__.__name__, "WidgetPaymentForm")
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("payu-widget", html)
+        self.assertIn("google-pay-button", html)
+        self.assertIn("https://pay.google.com/gp/p/js/pay.js", html)
+        self.assertIn('"environment": "PRODUCTION"', html)
+        self.assertIn('"gateway_merchant_id": "123abc"', html)
+        self.assertIn('"merchantId": "test_merchant_id"', html)
+        self.assertIn('"merchantName": "Test shop"', html)
+        self.assertIn('"total": "220.00"', html)
+        self.assertIn('"currency": "USD"', html)
+        self.assertIn("https://example.com/process_url/token", html)
+
+    def test_payu_widget_form_google_pay_sandbox(self):
+        """Test that the Google Pay button uses TEST environment on sandbox"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+            sandbox=True,
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn('"environment": "TEST"', html)
+
+    def test_payu_widget_form_google_pay_not_on_cvv(self):
+        """Test that the Google Pay button is not rendered on the CVV form"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        self.payment.extra_data = json.dumps({"cvv_url": "http://cvv.url"})
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("payu-widget", html)
+        self.assertNotIn("google-pay-button", html)
+
+    def test_process_google_pay(self):
+        """Test processing a Google Pay token callback with recurring FIRST"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        google_pay_token = '{"signature": "foo", "signedMessage": "bar"}'
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": google_pay_token}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            response = self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+            self.assertEqual(response.__class__.__name__, "HttpResponse")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.content, b"http://foo_succ.com")
+            mocked_post.assert_called_once_with(
+                "http://mock.url/api/v2_1/orders/",
+                allow_redirects=False,
+                data=JSONEquals(
+                    {
+                        "recurring": "FIRST",
+                        "customerIp": "123",
+                        "totalAmount": 22000,
+                        "description": "payment",
+                        "extOrderId": None,
+                        "products": [
+                            {
+                                "name": "foo",
+                                "subUnit": 100,
+                                "currency": "USD",
+                                "unitPrice": 2000,
+                                "quantity": 10,
+                            }
+                        ],
+                        "continueUrl": "http://foo_succ.com",
+                        "merchantPosId": "123abc",
+                        "currencyCode": "USD",
+                        "payMethods": {
+                            "payMethod": {
+                                "type": "PBL",
+                                "value": "ap",
+                                "authorizationCode": base64.b64encode(
+                                    google_pay_token.encode("utf-8")
+                                ).decode("ascii"),
+                            }
+                        },
+                        "buyer": {
+                            "firstName": "Foo",
+                            "email": "foo@bar.com",
+                            "language": "en",
+                            "phone": None,
+                            "lastName": "Bar",
+                        },
+                        "notifyUrl": "https://example.com/process_url/token",
+                    }
+                ),
+                headers={
+                    "Authorization": "Bearer test_access_token",
+                    "Content-Type": "application/json",
+                },
+            )
+        self.assertEqual(self.payment.status, PaymentStatus.WAITING)
+        self.assertEqual(self.payment.captured_amount, Decimal("0"))
+
+    def test_process_google_pay_non_recurring(self):
+        """Test that a one-off Google Pay order is sent without recurring"""
+        self.set_up_provider(
+            False,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        google_pay_token = '{"signature": "foo"}'
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": google_pay_token}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            response = self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+            self.assertEqual(response.status_code, 200)
+            sent_data = json.loads(mocked_post.call_args[1]["data"])
+            self.assertNotIn("recurring", sent_data)
+            self.assertEqual(
+                sent_data["payMethods"]["payMethod"],
+                {
+                    "type": "PBL",
+                    "value": "ap",
+                    "authorizationCode": base64.b64encode(
+                        google_pay_token.encode("utf-8")
+                    ).decode("ascii"),
+                },
+            )
+
+    def test_process_google_pay_3ds(self):
+        """Test that a Google Pay order requiring 3DS returns the redirect URL"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = json.dumps(
+                {
+                    "redirectUri": "test_redirect_uri",
+                    "status": {"statusCode": "WARNING_CONTINUE_3DS"},
+                    "orderId": 123,
+                }
+            )
+            post.status_code = 200
+            mocked_post.return_value = post
+            response = self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.content, b"test_redirect_uri")
+        self.assertEqual(
+            json.loads(self.payment.extra_data)["3ds_url"], "test_redirect_uri"
+        )
+
+    def test_process_google_pay_stores_multi_use_token(self):
+        """Test that a multi-use card token from a Google Pay order is stored"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = json.dumps(
+                {
+                    "status": {"statusCode": "SUCCESS"},
+                    "orderId": 123,
+                    "payMethods": {
+                        "payMethod": {
+                            "value": "TOKC_MULTI_USE",
+                            "card": {
+                                "expirationYear": 2031,
+                                "expirationMonth": 6,
+                                "number": "1234xxx",
+                            },
+                        }
+                    },
+                }
+            )
+            post.status_code = 200
+            mocked_post.return_value = post
+            self.provider.process_data(payment=self.payment, request=mocked_request)
+        self.assertEqual(self.payment.token, "TOKC_MULTI_USE")
+        self.assertEqual(self.payment.card_expire_year, 2031)
+        self.assertEqual(self.payment.card_expire_month, 6)
+        self.assertEqual(self.payment.card_masked_number, "1234xxx")
+        self.assertEqual(self.payment.renewal_triggered_by, "task")
+
+    def test_process_google_pay_paymethod_echo_not_stored(self):
+        """Test that a pay method echo without card data is not stored as a renew token"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = json.dumps(
+                {
+                    "status": {"statusCode": "SUCCESS"},
+                    "orderId": 123,
+                    "payMethods": {"payMethod": {"value": "ap", "type": "PBL"}},
+                }
+            )
+            post.status_code = 200
+            mocked_post.return_value = post
+            self.provider.process_data(payment=self.payment, request=mocked_request)
+        self.assertIsNone(self.payment.token)
 
     def test_process_notification(self):
         """Test processing PayU notification"""


### PR DESCRIPTION
## What

Adds an optional `google_pay` provider parameter that renders a Google Pay button above the PayU card widget in the express payment form.

## How it works

- The button uses the [Google Pay API](https://developers.google.com/pay/api/web/overview) with PayU as the gateway (`gateway: payu`, `gatewayMerchantId` defaulting to `pos_id`), shown only on capable devices (`isReadyToPay`).
- The returned wallet token is POSTed to the payment's process URL and charged through a standard PayU order as a pay-by-link `ap` method with a base64 `authorizationCode`, per [PayU's Google Pay docs](https://developers.payu.com/europe/docs/payment-solutions/cards/digital-wallets/google-pay/). Existing 3DS/CVV redirect handling and notification processing apply unchanged.
- With `recurring_payments=True`, the first Google Pay order is sent with `recurring=FIRST`; the multi-use card token PayU returns is stored via `Payment.set_renew_token()`, so server-initiated renewals (`autocomplete_with_wallet`, `recurring=STANDARD`) work exactly like card renewals.

## Bugfix included

`create_order` now only stores a renew token when the order response contains card data — a wallet order can echo the pay-by-link method (`ap`) without card details, and that value is not a reusable token; previously it would have overwritten the stored renew token (and crashed on the missing `card` key).

## Config

```python
'google_pay': {
    'merchant_id': 'BCR2DN...',        # required for PRODUCTION
    'merchant_name': 'My shop',        # optional
    # optional overrides: environment, gateway_merchant_id,
    # allowed_auth_methods, allowed_card_networks
}
```

## Testing

- 8 new tests (form rendering incl. sandbox/CVV exclusion, order payload incl. recurring FIRST and base64 authorizationCode, 3DS redirect, multi-use token storage, pay-method echo guard); full suite: 53 tests, all pass.
- flake8 and black clean.
- ⚠️ Not yet verified against the PayU sandbox — needs Google Pay enabled on the POS. In particular, the assumption that the multi-use token is returned in the create-order response `payMethods` (as in the card widget flow) should be confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)