### PR TITLE
Fix HtmlOutputField html being autoescaped on Django 5.x

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 
 History
 -------
+unreleased
+**********
+* fix HtmlOutputField rendering its html autoescaped on Django 5.x - the
+  "This payment is already being processed" error form showed literal
+  "<br/><strong>..." markup to the user.
+
 2.1.1 (2026-05-07)
 ******************
 * fix create_order demoting an already CONFIRMED payment to ERROR when PayU

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -10,6 +10,7 @@ import requests
 from django import forms
 from django.http.response import HttpResponse, HttpResponseRedirect
 from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 from payments import FraudStatus, PaymentStatus, RedirectNeeded
 from payments.core import BasicProvider, get_base_url
 from payments.forms import PaymentForm
@@ -93,7 +94,10 @@ class HtmlOutputField(forms.HiddenInput):
         return super(HtmlOutputField, self).__init__(*args, **kwargs)
 
     def render(self, *args, **kwargs):
-        return self.html
+        # mark_safe: a plain str gets autoescaped when the widget is rendered
+        # in a template (visible as literal "<br/><strong>..." on Django 5.x).
+        # The html is built by this module from trusted, server-side values.
+        return mark_safe(self.html)
 
 
 class WidgetPaymentForm(PaymentForm):

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -726,6 +726,26 @@ class TestPayuProvider(TestCase):
             self.assertIn("</script>", rendered_html)  # Test, that escaping works correctly
             self.assertIn("customer-language='cs'", rendered_html)
 
+    def test_payment_error_form_html_not_escaped(self):
+        """Test that the payment error form renders its html unescaped.
+
+        HtmlOutputField.render must return a safe string: a plain str gets
+        autoescaped when the form is rendered in a template on Django 5.x,
+        showing literal "<br/><strong>..." to the user.
+        """
+        from django.utils.safestring import SafeString
+
+        from payments_payu.provider import PaymentErrorForm
+
+        form = PaymentErrorForm()
+        rendered_widget = form.fields["script"].widget.render("script", None)
+        self.assertIsInstance(rendered_widget, SafeString)
+
+        template = Template("{{form.as_p}}")
+        rendered_html = template.render(Context({"form": form}))
+        self.assertIn("<strong>This payment is already being processed.", rendered_html)
+        self.assertNotIn("&lt;strong&gt;", rendered_html)
+
     def test_redirect_3ds_form(self):
         """Test redirection to 3DS page if requested by PayU"""
         self.set_up_provider(


### PR DESCRIPTION
## What

`HtmlOutputField.render()` returned a plain `str`. Django 5.x autoescapes it when the form is rendered in a template, so users hitting the "payment already being processed" state saw literal `<br/><strong>...` markup instead of the formatted message (observed in production-like environment on Django 5.2).

## Fix

Return `mark_safe(self.html)` — the html is built by this module from trusted server-side values. `WidgetPaymentForm` was unaffected only because `format_html` already returns a `SafeString`; `PaymentErrorForm` used a plain string literal.

## Testing

New regression test asserts the rendered widget is a `SafeString` (fails on every Django version pre-fix) and that template rendering keeps `<strong>` unescaped (the Django 5.x symptom). Suite green on Django 4.2 and 5.2 locally; flake8/black clean.

Independent of #23 (which needs the same treatment for its added markup and already carries it); this one targets master so it can ship as a patch release for production users on Django 5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)