### PR TITLE
Google Pay: dynamic-injection re-init guards + button_radius option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ unreleased
   proxy) raises ``PayuApiError`` instead of a raw ``JSONDecodeError``. The
   payment now fails cleanly (``ERROR`` status + redirect to the failure
   page) in the first two cases.
+* Google Pay: re-initialization guards for hosts that inject the express
+  form dynamically (skip double init, initialize when pay.js is already
+  loaded), and an optional ``button_radius`` key in the ``google_pay``
+  config passed to the button as ``buttonRadius``.
 
 2.2.0 (2026-07-03)
 ******************

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Here are valid parameters for the provider:
    :gateway_merchant_id:    (default: ``pos_id``) gateway merchant ID passed to the Google Pay tokenization specification
    :allowed_auth_methods:   (default: ``["PAN_ONLY", "CRYPTOGRAM_3DS"]``)
    :allowed_card_networks:  (default: ``["MASTERCARD", "VISA"]``)
+   :button_radius:          (optional) corner radius in px passed to the Google Pay button (``buttonRadius``)
 
 Example::
 

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -69,6 +69,12 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
         }
     };
     window.onGooglePayLoaded = function() {
+        var container = document.getElementById('google-pay-button');
+        if (!container || container.hasChildNodes()) {
+            // Already initialized (the form was re-rendered into the page and
+            // both the inline call and the script onload fired) - do nothing.
+            return;
+        }
         var client = new google.payments.api.PaymentsClient({environment: cfg.environment});
         client.isReadyToPay({
             apiVersion: 2,
@@ -78,8 +84,7 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
             if (!response.result) {
                 return;
             }
-            var container = document.getElementById('google-pay-button');
-            var button = client.createButton({buttonSizeMode: 'fill', onClick: function() {
+            var buttonOptions = {buttonSizeMode: 'fill', onClick: function() {
                 client.loadPaymentData({
                     apiVersion: 2,
                     apiVersionMinor: 0,
@@ -109,10 +114,18 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
                     document.body.classList.remove('payu-wallet-processing');
                     console.log('Google Pay payment did not complete', err);
                 });
-            }});
-            container.appendChild(button);
+            }};
+            if (cfg.button_radius !== null) {
+                buttonOptions.buttonRadius = cfg.button_radius;
+            }
+            container.appendChild(client.createButton(buttonOptions));
         });
     };
+    if (window.google && window.google.payments && window.google.payments.api) {
+        // pay.js is already loaded (the form was injected into an existing
+        // page) - the script tag below won't be re-evaluated, initialize now.
+        window.onGooglePayLoaded();
+    }
 })();
 </script>
 <script src="https://pay.google.com/gp/p/js/pay.js" async onload="onGooglePayLoaded()"></script>
@@ -422,6 +435,7 @@ class PayuProvider(BasicProvider):
             "total": str(payment.total.quantize(CENTS)),
             "currency": payment.currency,
             "merchant_info": merchant_info,
+            "button_radius": self.google_pay.get("button_radius"),
         }
         return GOOGLE_PAY_SCRIPT_TEMPLATE.substitute(
             # All config values come from provider settings, but escape "<"

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -938,6 +938,34 @@ class TestPayuProvider(TestCase):
         self.assertIn('"currency": "USD"', html)
         self.assertIn("https://example.com/process_url/token", html)
 
+    def test_payu_widget_form_google_pay_button_radius(self):
+        """Test that a configured button radius reaches the Google Pay config"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id", "button_radius": 22},
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn('"button_radius": 22', html)
+
+    def test_payu_widget_form_google_pay_reinit_guards(self):
+        """Test the re-injection guards: skip double init, init without onload"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("container.hasChildNodes()", html)
+        self.assertIn("window.google && window.google.payments", html)
+        self.assertIn('"button_radius": null', html)
+
     def test_payu_widget_form_google_pay_sandbox(self):
         """Test that the Google Pay button uses TEST environment on sandbox"""
         self.set_up_provider(


### PR DESCRIPTION
## What

Two small Google Pay improvements for hosts that inject the express form dynamically (e.g. an AJAX checkout panel that re-renders the provider form when the order total changes):

1. **Idempotent initialization** — `onGooglePayLoaded` no-ops when the button container is already populated, and runs immediately when `window.google.payments` is already present (a re-injected script tag isn't guaranteed to re-fire `onload`). Without these guards, re-injection could double-render the button or never initialize it.
2. **`button_radius` config key** — passed to `createButton` as `buttonRadius`, so the button can match the host's corner styling (Google's API supports this natively; no brand-guideline concerns).

## Testing

Two new rendering tests (radius in config JSON, guard markers present; default `button_radius: null`). Full suite 56/56 on Django 4.2 and 5.2, flake8 + black clean.

Used by BlenderKit's embedded one-page checkout (BlenderKit-server#2928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)