### PR TITLE
provider: survive malformed PayU error responses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 
 History
 -------
+unreleased
+**********
+* survive malformed PayU error responses: an integer ``status``
+  (``{"status": 500}``) no longer crashes ``post_request`` with
+  ``TypeError``, a missing ``codeLiteral`` no longer crashes the error log
+  with ``KeyError``, and a non-JSON body (e.g. an HTML 502 page from a
+  proxy) raises ``PayuApiError`` instead of a raw ``JSONDecodeError``. The
+  payment now fails cleanly (``ERROR`` status + redirect to the failure
+  page) in the first two cases.
+
 2.2.0 (2026-07-03)
 ******************
 * add optional Google Pay button to the express payment form (``google_pay``

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -502,11 +502,21 @@ class PayuProvider(BasicProvider):
         for i in range(1, self.retry_count):
             kwargs["headers"] = self.get_token_headers()
             response = requests.post(url, *args, **kwargs)
-            response_dict = json.loads(response.text)
+            try:
+                response_dict = json.loads(response.text)
+            except ValueError as e:
+                # Gateway-level failures (e.g. an HTML 502 page from a proxy)
+                # are not JSON; surface them as the provider's own exception.
+                raise PayuApiError(
+                    f"Non-JSON response from PayU: HTTP {response.status_code}, "
+                    f"body: {response.text[:200]!r}"
+                ) from e
+            # On gateway errors "status" can be a plain integer HTTP code
+            # ('{"status": 500}') instead of the usual status dict.
+            response_status = response_dict.get("status")
             if (response_dict.get("error") == "invalid_token") or (
-                "status" in response_dict
-                and "statusCode" in response_dict["status"]
-                and response_dict["status"]["statusCode"] == "UNAUTHORIZED"
+                isinstance(response_status, dict)
+                and response_status.get("statusCode") == "UNAUTHORIZED"
             ):
                 try:
                     self.token = self.get_access_token(
@@ -625,11 +635,18 @@ class PayuProvider(BasicProvider):
             elif response_dict["status"]["statusCode"] == "WARNING_CONTINUE_3DS":
                 add_extra_data(payment, {"3ds_url": response_dict["redirectUri"]})
                 return response_dict["redirectUri"]
-        except KeyError:
+        except (KeyError, TypeError):
+            # TypeError: on gateway errors "status" is a plain integer HTTP
+            # code, so the ["statusCode"] subscript above fails like a
+            # missing key does.
             pass
 
-        if "status" in response_dict:
-            if response_dict["status"]["statusCode"] == "BUSINESS_ERROR":
+        response_status = response_dict.get("status")
+        if response_status is not None:
+            if (
+                isinstance(response_status, dict)
+                and response_status.get("statusCode") == "BUSINESS_ERROR"
+            ):
                 # Payment rejected by PayUs anti-fruad system
                 payment.change_fraud_status(FraudStatus.REJECT, message=response_dict)
             else:
@@ -653,12 +670,14 @@ class PayuProvider(BasicProvider):
         try:
             raise PayuApiError(response_dict)
         except PayuApiError:
+            # codeLiteral is not guaranteed (and "status" may be an integer
+            # on gateway errors) - never let the error log itself crash.
             logger.exception(
                 "PayU API error:"
                 + (
-                    f"{response_dict['status']['codeLiteral']}"
-                    if "status" in response_dict
-                    else ""
+                    response_status.get("codeLiteral", "")
+                    if isinstance(response_status, dict)
+                    else str(response_status or "")
                 )
             )
         return payment_processor.failureUrl

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -601,6 +601,63 @@ class TestPayuProvider(TestCase):
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
 
+    def test_redirect_payu_integer_status_error(self):
+        """PayU gateway-level failures answer with a plain integer status
+        ('{"status": 500}') instead of the usual status dict. That must fail
+        the payment gracefully (ERROR + redirect to the failure page), not
+        crash with TypeError: argument of type 'int' is not iterable."""
+        self.set_up_provider(
+            True, False, get_refund_description=lambda payment, amount: "test"
+        )
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": 500, "error_description": "Internal Server Error"}'
+            post.status_code = 500
+            mocked_post.return_value = post
+            with self.assertRaises(RedirectNeeded) as context:
+                self.provider.get_form(payment=self.payment)
+            self.assertEqual(context.exception.args[0], "http://cancel.com")
+            self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+
+    def test_redirect_payu_error_without_code_literal(self):
+        """Error statuses are not guaranteed to carry codeLiteral; logging the
+        failure must not die with KeyError inside the except block."""
+        self.set_up_provider(
+            True, False, get_refund_description=lambda payment, amount: "test"
+        )
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = json.dumps(
+                {
+                    "status": {
+                        "statusCode": "ERROR_VALUE_INVALID",
+                        "statusDesc": "Order fields are invalid",
+                    }
+                }
+            )
+            post.status_code = 400
+            mocked_post.return_value = post
+            with self.assertRaises(RedirectNeeded) as context:
+                self.provider.get_form(payment=self.payment)
+            self.assertEqual(context.exception.args[0], "http://cancel.com")
+            self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+
+    def test_post_request_non_json_response_raises_payu_api_error(self):
+        """A gateway HTML error page (502 from a proxy) is not JSON; surface
+        it as PayuApiError instead of a raw JSONDecodeError."""
+        self.set_up_provider(
+            True, False, get_refund_description=lambda payment, amount: "test"
+        )
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = "<html><body>502 Bad Gateway</body></html>"
+            post.status_code = 502
+            mocked_post.return_value = post
+            with self.assertRaisesRegex(
+                PayuApiError, r"Non-JSON response from PayU: HTTP 502"
+            ):
+                self.provider.get_form(payment=self.payment)
+
     def test_get_access_token_trusted_merchant(self):
         self.set_up_provider(
             True, False, get_refund_description=lambda payment, amount: "test"


### PR DESCRIPTION
PayU gateway-level failures don't follow the documented response shape. Three distinct crashes were observed in production (BlenderKit Sentry):

1. **Integer status** — `{"status": 500}`: `post_request`'s token-expiry check did `"statusCode" in response_dict["status"]` → `TypeError: argument of type 'int' is not iterable`. `create_order`'s status handling had the same subscript problem.
2. **Missing `codeLiteral`** — the `create_order` error log formatted `response_dict['status']['codeLiteral']` → `KeyError` raised from inside the `except` block, replacing the real error.
3. **Non-JSON body** — an HTML 502 page from a proxy made `json.loads` raise a raw `JSONDecodeError`.

## Changes

- `post_request`: `isinstance(status, dict)` guard in the token-expiry condition; non-JSON bodies raise `PayuApiError` with the HTTP status and a body snippet.
- `create_order`: the happy-path probe also tolerates `TypeError` (integer status), the BUSINESS_ERROR check guards the status shape, and the error log uses `.get("codeLiteral")`.
- Cases 1 and 2 now fail the payment cleanly: `ERROR` status + redirect to the failure page, instead of a 500 for the paying user.

## Tests

Three new tests (integer status, missing codeLiteral, non-JSON body) — each reproduced its crash before the fix; full suite 57/57 green.

Replaces the monkey-patch approach from BlenderKit/blenderkit-server#1774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)