### PR TITLE
Add Apple Pay button to the express payment form

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,14 +103,20 @@ jobs:
            pip install requests-mock mock pytest coveralls
            pip install psycopg2==2.8.6
            pip install Django==${{ matrix.DJANGO_VERSION }} --pre
-           pip install codecov
 
       - name: Testing
         run: |
           PYTHONPATH=`pwd` python -W error::DeprecationWarning -m coverage run --source=payments_payu ./manage.py test
-          coverage xml && codecov
+          coverage xml
         env:
           DATABASE_URL: "postgresql://postgres:postgres@localhost/postgres"
+
+      # The legacy `codecov` PyPI uploader is shut down - its uploads silently
+      # disappeared (retries + dead v2 fallback), leaving stale PR reports.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,9 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
+          # Tokenless uploads are discarded for same-repo branches - the
+          # secret is required for reports to actually appear.
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,13 +12,13 @@ Unreleased
   ``CONFIRMED`` status is kept. Legitimate refunds are unaffected (they are
   handled by the dedicated ``refund`` branch). Mirrors the existing
   ``create_order`` guard added in 2.1.2.
-
-2.4.0 (2026-07-15)
-******************
-* Google Pay: add an optional ``button_color`` key in the ``google_pay``
-  config passed to the button as ``buttonColor`` (``"black"`` / ``"white"``
-  / ``"default"``). Google's brand guidelines require the white button on
-  dark backgrounds.
+* wallet tokens (Google Pay / Apple Pay) are validated before creating the
+  PayU order: a token missing its cryptographic parts now fails the payment
+  immediately with ``ERROR_WALLET_TOKEN_MALFORMED`` in ``extra_data``
+  instead of PayU's vague ``APPLE_PAY_CLIENT_ERROR``, and each accepted
+  token logs its non-sensitive metadata (the Apple Pay ``publicKeyHash``,
+  which identifies the payment-processing certificate the token was
+  encrypted for, and the Google Pay ``protocolVersion``) for diagnostics.
 * add optional Apple Pay button to the express payment form (``apple_pay``
   provider parameter). The Apple Pay ``token.paymentData`` (which carries the
   ``data``/``signature``/``header``/``version`` PayU decrypts) is charged
@@ -28,6 +28,13 @@ Unreleased
   and the returned multi-use card token is stored for renewals. Merchant
   validation (``onvalidatemerchant``) is handled by the provider using the
   configured Merchant Identity certificate.
+
+2.4.0 (2026-07-15)
+******************
+* Google Pay: add an optional ``button_color`` key in the ``google_pay``
+  config passed to the button as ``buttonColor`` (``"black"`` / ``"white"``
+  / ``"default"``). Google's brand guidelines require the white button on
+  dark backgrounds.
 
 2.3.0 (2026-07-04)
 ******************

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,13 @@ Unreleased
   config passed to the button as ``buttonColor`` (``"black"`` / ``"white"``
   / ``"default"``). Google's brand guidelines require the white button on
   dark backgrounds.
+* add optional Apple Pay button to the express payment form (``apple_pay``
+  provider parameter). The Apple Pay token is charged through a standard PayU
+  order (pay-by-link method ``jp`` with base64 ``authorizationCode``); with
+  ``recurring_payments=True`` the first order is sent with ``recurring=FIRST``
+  and the returned multi-use card token is stored for renewals. Merchant
+  validation (``onvalidatemerchant``) is handled by the provider using the
+  configured Merchant Identity certificate.
 
 2.3.0 (2026-07-04)
 ******************

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,8 +20,10 @@ Unreleased
   / ``"default"``). Google's brand guidelines require the white button on
   dark backgrounds.
 * add optional Apple Pay button to the express payment form (``apple_pay``
-  provider parameter). The Apple Pay token is charged through a standard PayU
-  order (pay-by-link method ``jp`` with base64 ``authorizationCode``); with
+  provider parameter). The Apple Pay ``token.paymentData`` (which carries the
+  ``data``/``signature``/``header``/``version`` PayU decrypts) is charged
+  through a standard PayU order (pay-by-link method ``jp`` with base64
+  ``authorizationCode``); with
   ``recurring_payments=True`` the first order is sent with ``recurring=FIRST``
   and the returned multi-use card token is stored for renewals. Merchant
   validation (``onvalidatemerchant``) is handled by the provider using the

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,42 @@ Example::
           }),
       }
 
+**Apple Pay**:
+   With ``express_payments=True`` the provider can render an Apple Pay button above the PayU card widget. The button appears only in Safari on a device that can make Apple Pay payments. The returned token is charged through the standard PayU order with a ``jp`` pay-by-link method; recurring works like Google Pay (first order ``recurring=FIRST`` -> multi-use token stored via ``Payment.set_renew_token()`` -> server-initiated renewals).
+
+   Apple Pay for the Web additionally requires **merchant validation**: when the payment sheet opens, the browser calls ``onvalidatemerchant`` and the provider POSTs to Apple using your **Merchant Identity certificate** to obtain a merchant session. This means, unlike Google Pay, you must have that certificate available to the server.
+
+   Setup checklist:
+
+   * Enable Apple Pay on your PayU POS and send PayU your **Payment Processing** certificate (PayU decrypts the token).
+   * Create an Apple **Merchant ID** and a **Merchant Identity** certificate; make it available to the app.
+   * Register and verify every domain that shows the button (serve ``/.well-known/apple-developer-merchantid-domain-association.txt``).
+   * If your site sends a Content-Security-Policy, allow the Apple Pay JS API (it is a browser API, no external script, but the button uses the ``-apple-pay-button`` appearance).
+
+   Valid keys of the ``apple_pay`` dict:
+
+   :merchant_id:            Apple Merchant ID, e.g. ``merchant.com.example`` (required)
+   :merchant_name:          merchant/display name shown in the sheet (defaults to ``shop_name``)
+   :country_code:           (default: ``"US"``) merchant country code
+   :certificate:            the Merchant Identity certificate, passed as-is to ``requests``'s ``cert=`` for merchant validation (a path to a combined PEM, or a ``(cert, key)`` tuple of paths)
+   :supported_networks:     (default: ``["masterCard", "visa"]``)
+   :merchant_capabilities:  (default: ``["supports3DS"]``)
+
+Example::
+
+      PAYMENT_VARIANTS = {
+          'payu': ('payments_payu.provider.PayuProvider', {
+              # ...
+              'express_payments': True,
+              'apple_pay': {
+                  'merchant_id': 'merchant.com.example',
+                  'merchant_name': 'My shop',
+                  'country_code': 'CZ',
+                  'certificate': '/path/to/merchant_identity.pem',
+              },
+          }),
+      }
+
 **Recurring payments**:
    If recurring payments are enabled, the PayU card token needs to be stored in your application for usage in next payments. The next payments can be either initiated by user through (user will be prompted only for payment confirmation by the express form) or by server.
    To enable recurring payments, you will need to set additional things:

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -134,6 +134,91 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
 <script src="https://pay.google.com/gp/p/js/pay.js" async onload="onGooglePayLoaded()"></script>
 """)
 
+APPLE_PAY_SUPPORTED_NETWORKS = ["masterCard", "visa"]
+APPLE_PAY_MERCHANT_CAPABILITIES = ["supports3DS"]
+
+# Apple Pay for the Web. The button appears only in Safari on a device that can
+# make payments. onvalidatemerchant and onpaymentauthorized both POST back to
+# the payment's process URL (dispatched by field name), so no extra endpoints
+# are needed. $config is server-built JSON; $process_url is the process URL.
+APPLE_PAY_SCRIPT_TEMPLATE = Template("""
+<style>
+.payu-apple-pay-button {
+    display: none;
+    -webkit-appearance: -apple-pay-button;
+    -apple-pay-button-type: plain;
+    -apple-pay-button-style: black;
+    width: 100%;
+    min-height: 40px;
+    cursor: pointer;
+}
+</style>
+<div id="apple-pay-button" class="payu-apple-pay-button" lang="en"></div>
+<script>
+(function() {
+    var cfg = $config;
+    function initApplePay() {
+        var button = document.getElementById('apple-pay-button');
+        if (!button || button.dataset.payuInit) {
+            return;
+        }
+        if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
+            return;
+        }
+        button.dataset.payuInit = '1';
+        button.style.display = 'block';
+        button.addEventListener('click', function() {
+            var request = {
+                countryCode: cfg.country_code,
+                currencyCode: cfg.currency,
+                supportedNetworks: cfg.supported_networks,
+                merchantCapabilities: cfg.merchant_capabilities,
+                total: {label: cfg.label, amount: cfg.total}
+            };
+            var session = new ApplePaySession(3, request);
+            session.onvalidatemerchant = function(event) {
+                var body = new URLSearchParams();
+                body.append('apple_pay_validation_url', event.validationURL);
+                fetch('$process_url', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: body.toString()
+                }).then(function(response) {
+                    return response.json();
+                }).then(function(merchantSession) {
+                    session.completeMerchantValidation(merchantSession);
+                }).catch(function(err) {
+                    console.log('Apple Pay merchant validation failed', err);
+                    session.abort();
+                });
+            };
+            session.onpaymentauthorized = function(event) {
+                document.body.classList.add('payu-wallet-processing');
+                var body = new URLSearchParams();
+                body.append('apple_pay_token', JSON.stringify(event.payment.token));
+                fetch('$process_url', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: body.toString()
+                }).then(function(response) {
+                    return response.text();
+                }).then(function(url) {
+                    session.completePayment(ApplePaySession.STATUS_SUCCESS);
+                    window.location.href = url;
+                }).catch(function(err) {
+                    document.body.classList.remove('payu-wallet-processing');
+                    session.completePayment(ApplePaySession.STATUS_FAILURE);
+                    console.log('Apple Pay payment did not complete', err);
+                });
+            };
+            session.begin();
+        });
+    }
+    initApplePay();
+})();
+</script>
+""")
+
 
 def add_extra_data(payment, new_extra_data):
     payment.refresh_from_db(fields=["extra_data"])
@@ -197,15 +282,22 @@ class WidgetPaymentForm(PaymentForm):
     script = forms.CharField(label="Script")
 
     def __init__(
-        self, payu_base_url, script_params={}, google_pay_html="", *args, **kwargs
+        self,
+        payu_base_url,
+        script_params={},
+        google_pay_html="",
+        apple_pay_html="",
+        *args,
+        **kwargs,
     ):
         ret = super(WidgetPaymentForm, self).__init__(*args, **kwargs)
         # mark_safe: plain-str concatenation would demote format_html's
-        # SafeString and get the whole widget HTML escaped when rendered.
-        # google_pay_html is server-built (no user input, see
-        # PayuProvider.get_google_pay_html).
+        # SafeString and get the whole widget HTML escaped when rendered. The
+        # wallet HTML is server-built (no user input, see
+        # PayuProvider.get_google_pay_html / get_apple_pay_html).
         form_html = mark_safe(
             google_pay_html
+            + apple_pay_html
             + format_html(
                 "<script "
                 f"src='{payu_base_url}front/widget/js/payu-bootstrap.js' "
@@ -322,6 +414,12 @@ class PayuProvider(BasicProvider):
         # A dict with optional keys: merchant_id, merchant_name, environment,
         # gateway_merchant_id, allowed_auth_methods, allowed_card_networks.
         self.google_pay = kwargs.pop("google_pay", None)
+        # Apple Pay express button, only valid with express_payments=True. A
+        # dict with keys: merchant_id, merchant_name (display name), country_code,
+        # certificate (anything requests accepts as cert= for the merchant
+        # identity certificate used in Apple merchant validation), and optional
+        # supported_networks / merchant_capabilities.
+        self.apple_pay = kwargs.pop("apple_pay", None)
         self.retry_count = 5
 
         self.pos_id = kwargs.pop("pos_id")
@@ -409,6 +507,7 @@ class PayuProvider(BasicProvider):
             data=data,
             script_params=payu_data,
             google_pay_html=self.get_google_pay_html(payment) if not cvv_url else "",
+            apple_pay_html=self.get_apple_pay_html(payment) if not cvv_url else "",
             provider=self,
             payment=payment,
         )
@@ -448,6 +547,78 @@ class PayuProvider(BasicProvider):
             config=json.dumps(config).replace("<", "\\u003c"),
             process_url=urljoin(get_base_url(), payment.get_process_url()),
         )
+
+    def get_apple_pay_html(self, payment):
+        """Render the Apple Pay button + JS for the express payment form."""
+        if not self.apple_pay:
+            return ""
+        config = {
+            "country_code": self.apple_pay.get("country_code", "US"),
+            "currency": payment.currency,
+            "total": str(payment.total.quantize(CENTS)),
+            "label": self.apple_pay.get("merchant_name") or self.payu_shop_name,
+            "supported_networks": self.apple_pay.get(
+                "supported_networks", APPLE_PAY_SUPPORTED_NETWORKS
+            ),
+            "merchant_capabilities": self.apple_pay.get(
+                "merchant_capabilities", APPLE_PAY_MERCHANT_CAPABILITIES
+            ),
+        }
+        return APPLE_PAY_SCRIPT_TEMPLATE.substitute(
+            config=json.dumps(config).replace("<", "\\u003c"),
+            process_url=urljoin(get_base_url(), payment.get_process_url()),
+        )
+
+    def validate_apple_pay_merchant(self, validation_url):
+        """Exchange Apple's validationURL for a merchant session.
+
+        Apple Pay for the Web requires the merchant server to authenticate to
+        Apple with the Merchant Identity certificate before the payment sheet
+        opens. Returns the merchant session dict to hand back to the browser.
+        """
+        domain = urljoin(get_base_url(), "/").split("://", 1)[-1].strip("/")
+        payload = {
+            "merchantIdentifier": self.apple_pay["merchant_id"],
+            "displayName": self.apple_pay.get("merchant_name") or self.payu_shop_name,
+            "initiative": "web",
+            "initiativeContext": domain,
+        }
+        response = requests.post(
+            validation_url,
+            json=payload,
+            cert=self.apple_pay.get("certificate"),
+        )
+        return response.json()
+
+    def process_apple_pay_validation(self, payment, validation_url):
+        return HttpResponse(
+            json.dumps(self.validate_apple_pay_merchant(validation_url)),
+            content_type="application/json",
+            status=200,
+        )
+
+    def process_apple_pay_callback(self, payment, apple_pay_token):
+        """Charge an order with an Apple Pay token from the express form.
+
+        PayU expects the raw Apple Pay token base64-encoded in the
+        authorizationCode of a "jp" pay-by-link method. As with Google Pay, the
+        first payment of a recurring plan is sent with recurring=FIRST so PayU
+        issues a multi-use card token for later renewals.
+        """
+        processor = self.get_processor(payment)
+        if self.card_on_file:
+            processor.cardOnFile = "FIRST"
+        elif self.recurring_payments:
+            processor.recurring = "FIRST"
+        processor.set_paymethod(
+            method_type="PBL",
+            value="jp",
+            authorization_code=base64.b64encode(apple_pay_token.encode("utf-8")).decode(
+                "ascii"
+            ),
+        )
+        data = self.create_order(payment, processor)
+        return HttpResponse(data, status=200)
 
     def get_processor(self, payment):
         order = payment.get_purchased_items()
@@ -856,6 +1027,14 @@ class PayuProvider(BasicProvider):
         elif "google_pay_token" in request.POST:
             return self.process_google_pay_callback(
                 payment, request.POST["google_pay_token"]
+            )
+        elif "apple_pay_validation_url" in request.POST:
+            return self.process_apple_pay_validation(
+                payment, request.POST["apple_pay_validation_url"]
+            )
+        elif "apple_pay_token" in request.POST:
+            return self.process_apple_pay_callback(
+                payment, request.POST["apple_pay_token"]
             )
         elif renew_token and self.recurring_payments:
             return self.process_widget_callback(

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -195,7 +195,7 @@ APPLE_PAY_SCRIPT_TEMPLATE = Template("""
             session.onpaymentauthorized = function(event) {
                 document.body.classList.add('payu-wallet-processing');
                 var body = new URLSearchParams();
-                body.append('apple_pay_token', JSON.stringify(event.payment.token));
+                body.append('apple_pay_token', JSON.stringify(event.payment.token.paymentData));
                 fetch('$process_url', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/x-www-form-urlencoded'},

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -636,37 +636,38 @@ class PayuProvider(BasicProvider):
             return None
         return token
 
-    def process_apple_pay_callback(self, payment, apple_pay_token):
-        """Charge an order with an Apple Pay token from the express form.
-
-        PayU expects the raw Apple Pay token base64-encoded in the
-        authorizationCode of a "jp" pay-by-link method. As with Google Pay, the
-        first payment of a recurring plan is sent with recurring=FIRST so PayU
-        issues a multi-use card token for later renewals.
-        """
-        token = self._parse_wallet_token(
-            payment,
-            "Apple Pay",
-            apple_pay_token,
-            ("version", "data", "signature", "header"),
+    @staticmethod
+    def _apple_pay_token_metadata(token):
+        # The publicKeyHash identifies the Apple Pay payment-processing
+        # certificate the token was encrypted for - the first thing to compare
+        # when PayU reports the certificate as unknown to it.
+        header = token["header"]
+        public_key_hash = (
+            header.get("publicKeyHash") if isinstance(header, dict) else None
         )
+        return "version={} publicKeyHash={}".format(token["version"], public_key_hash)
+
+    @staticmethod
+    def _google_pay_token_metadata(token):
+        return "protocolVersion={}".format(token["protocolVersion"])
+
+    def _process_wallet_callback(
+        self, payment, wallet, token_str, required_fields, pbl_value, metadata
+    ):
+        """Validate a wallet token, log its metadata and charge it as an order.
+
+        PayU expects the raw wallet token base64-encoded in the
+        authorizationCode of a pay-by-link method ("jp" for Apple Pay, "ap"
+        for Google Pay). The first payment of a recurring plan is sent with
+        recurring=FIRST (or cardOnFile=FIRST) so PayU issues a multi-use card
+        token for later renewals.
+        """
+        token = self._parse_wallet_token(payment, wallet, token_str, required_fields)
         if token is None:
             return HttpResponse(
                 urljoin(get_base_url(), payment.get_failure_url()), status=200
             )
-        # The publicKeyHash identifies the Apple Pay payment-processing
-        # certificate the token was encrypted for - the first thing to compare
-        # when PayU reports the certificate as unknown to it.
-        logger.info(
-            "Apple Pay token for payment %s: version=%s publicKeyHash=%s",
-            payment.pk,
-            token["version"],
-            (
-                token["header"].get("publicKeyHash")
-                if isinstance(token["header"], dict)
-                else None
-            ),
-        )
+        logger.info("%s token for payment %s: %s", wallet, payment.pk, metadata(token))
         processor = self.get_processor(payment)
         if self.card_on_file:
             processor.cardOnFile = "FIRST"
@@ -674,13 +675,23 @@ class PayuProvider(BasicProvider):
             processor.recurring = "FIRST"
         processor.set_paymethod(
             method_type="PBL",
-            value="jp",
-            authorization_code=base64.b64encode(apple_pay_token.encode("utf-8")).decode(
+            value=pbl_value,
+            authorization_code=base64.b64encode(token_str.encode("utf-8")).decode(
                 "ascii"
             ),
         )
         data = self.create_order(payment, processor)
         return HttpResponse(data, status=200)
+
+    def process_apple_pay_callback(self, payment, apple_pay_token):
+        return self._process_wallet_callback(
+            payment,
+            wallet="Apple Pay",
+            token_str=apple_pay_token,
+            required_fields=("version", "data", "signature", "header"),
+            pbl_value="jp",
+            metadata=self._apple_pay_token_metadata,
+        )
 
     def get_processor(self, payment):
         order = payment.get_purchased_items()
@@ -727,42 +738,14 @@ class PayuProvider(BasicProvider):
         return HttpResponse(data, status=200)
 
     def process_google_pay_callback(self, payment, google_pay_token):
-        """Charge an order with a Google Pay token from the express form.
-
-        PayU expects the raw Google Pay token base64-encoded in the
-        authorizationCode of an "ap" pay-by-link method. The first payment of
-        a recurring plan is sent with recurring=FIRST so PayU issues a
-        multi-use card token for later renewals.
-        """
-        token = self._parse_wallet_token(
+        return self._process_wallet_callback(
             payment,
-            "Google Pay",
-            google_pay_token,
-            ("protocolVersion", "signature", "signedMessage"),
+            wallet="Google Pay",
+            token_str=google_pay_token,
+            required_fields=("protocolVersion", "signature", "signedMessage"),
+            pbl_value="ap",
+            metadata=self._google_pay_token_metadata,
         )
-        if token is None:
-            return HttpResponse(
-                urljoin(get_base_url(), payment.get_failure_url()), status=200
-            )
-        logger.info(
-            "Google Pay token for payment %s: protocolVersion=%s",
-            payment.pk,
-            token["protocolVersion"],
-        )
-        processor = self.get_processor(payment)
-        if self.card_on_file:
-            processor.cardOnFile = "FIRST"
-        elif self.recurring_payments:
-            processor.recurring = "FIRST"
-        processor.set_paymethod(
-            method_type="PBL",
-            value="ap",
-            authorization_code=base64.b64encode(
-                google_pay_token.encode("utf-8")
-            ).decode("ascii"),
-        )
-        data = self.create_order(payment, processor)
-        return HttpResponse(data, status=200)
 
     def post_request(self, url, *args, **kwargs):
         for i in range(1, self.retry_count):

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -597,6 +597,45 @@ class PayuProvider(BasicProvider):
             status=200,
         )
 
+    def _parse_wallet_token(self, payment, wallet, token_str, required_fields):
+        """Parse a wallet token and fail fast when it is malformed.
+
+        A token missing its cryptographic parts would otherwise only fail
+        after the PayU round trip with a vague error (e.g.
+        APPLE_PAY_CLIENT_ERROR "signature is empty"). Returns the parsed
+        token dict, or None after erroring the payment.
+        """
+        try:
+            token = json.loads(token_str)
+        except json.JSONDecodeError:
+            token = None
+        missing = (
+            [field for field in required_fields if not token.get(field)]
+            if isinstance(token, dict)
+            else list(required_fields)
+        )
+        if missing:
+            logger.error(
+                "%s token for payment %s is malformed (missing: %s), "
+                "failing the payment without calling PayU",
+                wallet,
+                payment.pk,
+                ", ".join(missing),
+            )
+            add_extra_data(
+                payment,
+                {
+                    "status": {
+                        "statusCode": "ERROR_WALLET_TOKEN_MALFORMED",
+                        "wallet": wallet,
+                        "missing": missing,
+                    }
+                },
+            )
+            payment.change_status(PaymentStatus.ERROR)
+            return None
+        return token
+
     def process_apple_pay_callback(self, payment, apple_pay_token):
         """Charge an order with an Apple Pay token from the express form.
 
@@ -605,6 +644,29 @@ class PayuProvider(BasicProvider):
         first payment of a recurring plan is sent with recurring=FIRST so PayU
         issues a multi-use card token for later renewals.
         """
+        token = self._parse_wallet_token(
+            payment,
+            "Apple Pay",
+            apple_pay_token,
+            ("version", "data", "signature", "header"),
+        )
+        if token is None:
+            return HttpResponse(
+                urljoin(get_base_url(), payment.get_failure_url()), status=200
+            )
+        # The publicKeyHash identifies the Apple Pay payment-processing
+        # certificate the token was encrypted for - the first thing to compare
+        # when PayU reports the certificate as unknown to it.
+        logger.info(
+            "Apple Pay token for payment %s: version=%s publicKeyHash=%s",
+            payment.pk,
+            token["version"],
+            (
+                token["header"].get("publicKeyHash")
+                if isinstance(token["header"], dict)
+                else None
+            ),
+        )
         processor = self.get_processor(payment)
         if self.card_on_file:
             processor.cardOnFile = "FIRST"
@@ -672,6 +734,21 @@ class PayuProvider(BasicProvider):
         a recurring plan is sent with recurring=FIRST so PayU issues a
         multi-use card token for later renewals.
         """
+        token = self._parse_wallet_token(
+            payment,
+            "Google Pay",
+            google_pay_token,
+            ("protocolVersion", "signature", "signedMessage"),
+        )
+        if token is None:
+            return HttpResponse(
+                urljoin(get_base_url(), payment.get_failure_url()), status=200
+            )
+        logger.info(
+            "Google Pay token for payment %s: protocolVersion=%s",
+            payment.pk,
+            token["protocolVersion"],
+        )
         processor = self.get_processor(payment)
         if self.card_on_file:
             processor.cardOnFile = "FIRST"

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -1248,6 +1248,9 @@ class TestPayuProvider(TestCase):
         self.assertIn('"total": "220.00"', html)
         self.assertIn('"currency": "USD"', html)
         self.assertIn("https://example.com/process_url/token", html)
+        # PayU decrypts token.paymentData (its data/signature/header/version),
+        # not the whole ApplePayPaymentToken wrapper.
+        self.assertIn("JSON.stringify(event.payment.token.paymentData)", html)
 
     def test_payu_widget_form_apple_pay_not_on_cvv(self):
         """Test that the Apple Pay button is not rendered on the CVV form"""

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -1362,6 +1362,69 @@ class TestPayuProvider(TestCase):
             self.assertNotIn("recurring", sent_data)
             self.assertEqual(sent_data["payMethods"]["payMethod"]["value"], "jp")
 
+    def test_process_apple_pay_card_on_file(self):
+        """With card_on_file, an Apple Pay order uses cardOnFile=FIRST, not recurring."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+            card_on_file=True,
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"apple_pay_token": '{"paymentData": {}}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            self.provider.process_data(payment=self.payment, request=mocked_request)
+            sent_data = json.loads(mocked_post.call_args[1]["data"])
+            self.assertEqual(sent_data["cardOnFile"], "FIRST")
+            self.assertNotIn("recurring", sent_data)
+            self.assertEqual(sent_data["payMethods"]["payMethod"]["value"], "jp")
+
+    def test_process_google_pay_card_on_file(self):
+        """With card_on_file, a Google Pay order uses cardOnFile=FIRST, not recurring."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+            card_on_file=True,
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            self.provider.process_data(payment=self.payment, request=mocked_request)
+            sent_data = json.loads(mocked_post.call_args[1]["data"])
+            self.assertEqual(sent_data["cardOnFile"], "FIRST")
+            self.assertNotIn("recurring", sent_data)
+            self.assertEqual(sent_data["payMethods"]["payMethod"]["value"], "ap")
+
+    def test_payu_widget_form_google_pay_without_merchant_id(self):
+        """Google Pay in TEST mode needs no merchant_id; merchantId is then omitted."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_name": "Test shop"},
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("google-pay-button", html)
+        self.assertIn('"merchantName": "Test shop"', html)
+        self.assertNotIn("merchantId", html)
+
     def test_process_notification(self):
         """Test processing PayU notification"""
         self.set_up_provider(

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -4,11 +4,11 @@ import base64
 import contextlib
 import json
 import warnings
-from django.template import Context, Template
 from copy import deepcopy
 from decimal import Decimal
 from unittest import TestCase
 
+from django.template import Context, Template
 from mock import MagicMock, Mock, patch
 from payments import FraudStatus, PaymentStatus, PurchasedItem, RedirectNeeded
 
@@ -26,6 +26,29 @@ PROCESS_DATA = {
     "expiration_1": "2020",
     "cvv2": "1234",
 }
+
+# Realistic wallet token shapes - the provider validates these fields before
+# forwarding the token to PayU.
+APPLE_PAY_TOKEN = json.dumps(
+    {
+        "version": "EC_v1",
+        "data": "encrypted-payment-data",
+        "signature": "test-signature",
+        "header": {
+            "publicKeyHash": "test-public-key-hash",
+            "ephemeralPublicKey": "test-ephemeral-key",
+            "transactionId": "test-transaction-id",
+        },
+    }
+)
+GOOGLE_PAY_TOKEN = json.dumps(
+    {
+        "protocolVersion": "ECv2",
+        "signature": "test-signature",
+        "intermediateSigningKey": {"signedKey": "key", "signatures": ["sig"]},
+        "signedMessage": "test-signed-message",
+    }
+)
 
 
 class JSONEquals(str):
@@ -1029,7 +1052,7 @@ class TestPayuProvider(TestCase):
             google_pay={"merchant_id": "test_merchant_id"},
         )
         self.payment.token = None
-        google_pay_token = '{"signature": "foo", "signedMessage": "bar"}'
+        google_pay_token = GOOGLE_PAY_TOKEN
         mocked_request = MagicMock()
         mocked_request.POST = {"google_pay_token": google_pay_token}
         mocked_request.META = {}
@@ -1102,7 +1125,7 @@ class TestPayuProvider(TestCase):
             google_pay={"merchant_id": "test_merchant_id"},
         )
         self.payment.token = None
-        google_pay_token = '{"signature": "foo"}'
+        google_pay_token = GOOGLE_PAY_TOKEN
         mocked_request = MagicMock()
         mocked_request.POST = {"google_pay_token": google_pay_token}
         mocked_request.META = {}
@@ -1138,7 +1161,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.POST = {"google_pay_token": GOOGLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()
@@ -1170,7 +1193,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.POST = {"google_pay_token": GOOGLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()
@@ -1209,7 +1232,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.POST = {"google_pay_token": GOOGLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()
@@ -1316,7 +1339,7 @@ class TestPayuProvider(TestCase):
             apple_pay={"merchant_id": "merchant.com.test"},
         )
         self.payment.token = None
-        apple_pay_token = '{"paymentData": {"data": "encrypted"}}'
+        apple_pay_token = APPLE_PAY_TOKEN
         mocked_request = MagicMock()
         mocked_request.POST = {"apple_pay_token": apple_pay_token}
         mocked_request.META = {}
@@ -1353,7 +1376,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"apple_pay_token": '{"paymentData": {}}'}
+        mocked_request.POST = {"apple_pay_token": APPLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()
@@ -1376,7 +1399,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"apple_pay_token": '{"paymentData": {}}'}
+        mocked_request.POST = {"apple_pay_token": APPLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()
@@ -1389,6 +1412,121 @@ class TestPayuProvider(TestCase):
             self.assertNotIn("recurring", sent_data)
             self.assertEqual(sent_data["payMethods"]["payMethod"]["value"], "jp")
 
+    def test_process_apple_pay_malformed_token(self):
+        """A malformed Apple Pay token fails fast without calling PayU.
+
+        A token missing its cryptographic parts (e.g. the whole
+        ApplePayPaymentToken wrapper sent instead of its paymentData) would
+        only fail after the PayU round trip with a vague APPLE_PAY_CLIENT_ERROR.
+        """
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"apple_pay_token": '{"paymentData": {"data": "x"}}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            with self.assertLogs("payments_payu.provider", level="ERROR") as logs:
+                response = self.provider.process_data(
+                    payment=self.payment, request=mocked_request
+                )
+        mocked_post.assert_not_called()
+        self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"http://cancel.com")
+        self.assertIn("version, data, signature, header", logs.output[0])
+        self.assertEqual(
+            json.loads(self.payment.extra_data)["status"],
+            {
+                "statusCode": "ERROR_WALLET_TOKEN_MALFORMED",
+                "wallet": "Apple Pay",
+                "missing": ["version", "data", "signature", "header"],
+            },
+        )
+
+    def test_process_google_pay_non_json_token(self):
+        """A Google Pay token that is not JSON fails fast without calling PayU."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": "garbage"}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            with self.assertLogs("payments_payu.provider", level="ERROR") as logs:
+                response = self.provider.process_data(
+                    payment=self.payment, request=mocked_request
+                )
+        mocked_post.assert_not_called()
+        self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+        self.assertEqual(response.content, b"http://cancel.com")
+        self.assertIn("protocolVersion, signature, signedMessage", logs.output[0])
+
+    def test_process_apple_pay_logs_token_metadata(self):
+        """The Apple Pay publicKeyHash is logged for certificate diagnostics."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"apple_pay_token": APPLE_PAY_TOKEN}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            with self.assertLogs("payments_payu.provider", level="INFO") as logs:
+                self.provider.process_data(payment=self.payment, request=mocked_request)
+        self.assertTrue(
+            any(
+                "Apple Pay token for payment" in line
+                and "version=EC_v1" in line
+                and "publicKeyHash=test-public-key-hash" in line
+                for line in logs.output
+            ),
+            logs.output,
+        )
+
+    def test_process_google_pay_logs_token_metadata(self):
+        """The Google Pay protocolVersion is logged for diagnostics."""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"google_pay_token": GOOGLE_PAY_TOKEN}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            with self.assertLogs("payments_payu.provider", level="INFO") as logs:
+                self.provider.process_data(payment=self.payment, request=mocked_request)
+        self.assertTrue(
+            any(
+                "Google Pay token for payment" in line
+                and "protocolVersion=ECv2" in line
+                for line in logs.output
+            ),
+            logs.output,
+        )
+
     def test_process_google_pay_card_on_file(self):
         """With card_on_file, a Google Pay order uses cardOnFile=FIRST, not recurring."""
         self.set_up_provider(
@@ -1400,7 +1538,7 @@ class TestPayuProvider(TestCase):
         )
         self.payment.token = None
         mocked_request = MagicMock()
-        mocked_request.POST = {"google_pay_token": '{"signature": "foo"}'}
+        mocked_request.POST = {"google_pay_token": GOOGLE_PAY_TOKEN}
         mocked_request.META = {}
         with patch("requests.post") as mocked_post:
             post = MagicMock()

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -1225,6 +1225,143 @@ class TestPayuProvider(TestCase):
             self.provider.process_data(payment=self.payment, request=mocked_request)
         self.assertIsNone(self.payment.token)
 
+    def test_payu_widget_form_apple_pay(self):
+        """Test that the Apple Pay button is rendered in the express form"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={
+                "merchant_id": "merchant.com.test",
+                "merchant_name": "Test shop",
+                "country_code": "CZ",
+            },
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("payu-widget", html)
+        self.assertIn("apple-pay-button", html)
+        self.assertIn("ApplePaySession", html)
+        self.assertIn('"country_code": "CZ"', html)
+        self.assertIn('"label": "Test shop"', html)
+        self.assertIn('"total": "220.00"', html)
+        self.assertIn('"currency": "USD"', html)
+        self.assertIn("https://example.com/process_url/token", html)
+
+    def test_payu_widget_form_apple_pay_not_on_cvv(self):
+        """Test that the Apple Pay button is not rendered on the CVV form"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+        )
+        self.payment.token = None
+        self.payment.extra_data = json.dumps({"cvv_url": "http://cvv.url"})
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn("payu-widget", html)
+        self.assertNotIn("apple-pay-button", html)
+
+    def test_apple_pay_merchant_validation(self):
+        """Test that merchant validation POSTs to Apple with the identity cert"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={
+                "merchant_id": "merchant.com.test",
+                "merchant_name": "Test shop",
+                "certificate": ("/tmp/cert.pem", "/tmp/key.pem"),
+            },
+        )
+        mocked_request = MagicMock()
+        mocked_request.POST = {
+            "apple_pay_validation_url": "https://apple.example/validate"
+        }
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.json.return_value = {"merchantSessionIdentifier": "abc"}
+            mocked_post.return_value = post
+            response = self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response["Content-Type"], "application/json")
+            self.assertEqual(
+                json.loads(response.content), {"merchantSessionIdentifier": "abc"}
+            )
+            mocked_post.assert_called_once_with(
+                "https://apple.example/validate",
+                json={
+                    "merchantIdentifier": "merchant.com.test",
+                    "displayName": "Test shop",
+                    "initiative": "web",
+                    "initiativeContext": "example.com",
+                },
+                cert=("/tmp/cert.pem", "/tmp/key.pem"),
+            )
+
+    def test_process_apple_pay(self):
+        """Test processing an Apple Pay token callback with recurring FIRST"""
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+        )
+        self.payment.token = None
+        apple_pay_token = '{"paymentData": {"data": "encrypted"}}'
+        mocked_request = MagicMock()
+        mocked_request.POST = {"apple_pay_token": apple_pay_token}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            response = self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.content, b"http://foo_succ.com")
+            sent_data = json.loads(mocked_post.call_args[1]["data"])
+            self.assertEqual(sent_data["recurring"], "FIRST")
+            self.assertEqual(
+                sent_data["payMethods"]["payMethod"],
+                {
+                    "type": "PBL",
+                    "value": "jp",
+                    "authorizationCode": base64.b64encode(
+                        apple_pay_token.encode("utf-8")
+                    ).decode("ascii"),
+                },
+            )
+
+    def test_process_apple_pay_non_recurring(self):
+        """Test that a one-off Apple Pay order is sent without recurring"""
+        self.set_up_provider(
+            False,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            apple_pay={"merchant_id": "merchant.com.test"},
+        )
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"apple_pay_token": '{"paymentData": {}}'}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = '{"status": {"statusCode": "SUCCESS"}, "orderId": 123}'
+            post.status_code = 200
+            mocked_post.return_value = post
+            self.provider.process_data(payment=self.payment, request=mocked_request)
+            sent_data = json.loads(mocked_post.call_args[1]["data"])
+            self.assertNotIn("recurring", sent_data)
+            self.assertEqual(sent_data["payMethods"]["payMethod"]["value"], "jp")
+
     def test_process_notification(self):
         """Test processing PayU notification"""
         self.set_up_provider(


### PR DESCRIPTION
## What

Adds an optional `apple_pay` provider parameter that renders an Apple Pay button above the PayU card widget, mirroring the Google Pay support (#23).

## How it works

- **Button**: Safari-only, gated on `ApplePaySession.canMakePayments()` (hidden elsewhere), styled via the `-apple-pay-button` appearance and sized to fill the container.
- **Merchant validation** (the piece Google Pay didn't need): on `onvalidatemerchant`, the browser POSTs the `validationURL` to the payment's process URL; the provider calls Apple with the configured **Merchant Identity certificate** (`requests`'s `cert=`) and returns the merchant session.
- **Charge**: on `onpaymentauthorized`, the token POSTs to the process URL and is charged as a PayU `jp` pay-by-link order with a base64 `authorizationCode`, reusing the shared `create_order` path — so 3DS redirects, notifications and refunds are unchanged.
- **Recurring**: identical to Google Pay — `recurring=FIRST` on the first order, multi-use token stored via `set_renew_token()` for server-initiated renewals (proven end-to-end for the wallet flow in #23's sandbox testing).

Both round-trips are dispatched in `process_data` by POST field name (`apple_pay_validation_url` / `apple_pay_token`), same design as `google_pay_token`.

## Config

```python
'apple_pay': {
    'merchant_id': 'merchant.com.example',
    'merchant_name': 'My shop',
    'country_code': 'CZ',
    'certificate': '/path/to/merchant_identity.pem',  # or (cert, key) tuple
}
```

## Testing

- 6 new tests: button rendered (with config), not rendered on the CVV form, merchant-validation POST payload + cert, `jp` charge with recurring FIRST, and a one-off (no recurring). Full suite: **64 tests, green on Django 4.2 and 5.2**; flake8 + black clean.
- ⚠️ **Not yet verified against a live Apple Pay session** — needs the Merchant Identity certificate, PayU POS Apple Pay enablement (already on for our POS), and a Mac/iPhone. The base64-of-token shape sent to PayU (as with Google Pay's assumption) should be confirmed in sandbox; PayU may want `token.paymentData` rather than the full token JSON — a one-line change if so.

## Notes

Depends conceptually on #23 (shares the wallet-processing CSS hooks and the `set_paymethod` authorizationCode support, both already on master via 2.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)