### PR TITLE
Google Pay: add button_color option for dark backgrounds

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 
 History
 -------
+unreleased
+**********
+* Google Pay: add an optional ``button_color`` key in the ``google_pay``
+  config passed to the button as ``buttonColor`` (``"black"`` / ``"white"``
+  / ``"default"``). Google's brand guidelines require the white button on
+  dark backgrounds.
+
 2.3.0 (2026-07-04)
 ******************
 * survive malformed PayU error responses: an integer ``status``

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Here are valid parameters for the provider:
    :allowed_auth_methods:   (default: ``["PAN_ONLY", "CRYPTOGRAM_3DS"]``)
    :allowed_card_networks:  (default: ``["MASTERCARD", "VISA"]``)
    :button_radius:          (optional) corner radius in px passed to the Google Pay button (``buttonRadius``)
+   :button_color:           (optional) ``"black"``, ``"white"`` or ``"default"`` (``buttonColor``); use ``"white"`` on dark backgrounds per Google's brand guidelines
 
 Example::
 

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -118,6 +118,9 @@ GOOGLE_PAY_SCRIPT_TEMPLATE = Template("""
             if (cfg.button_radius !== null) {
                 buttonOptions.buttonRadius = cfg.button_radius;
             }
+            if (cfg.button_color !== null) {
+                buttonOptions.buttonColor = cfg.button_color;
+            }
             container.appendChild(client.createButton(buttonOptions));
         });
     };
@@ -436,6 +439,7 @@ class PayuProvider(BasicProvider):
             "currency": payment.currency,
             "merchant_info": merchant_info,
             "button_radius": self.google_pay.get("button_radius"),
+            "button_color": self.google_pay.get("button_color"),
         }
         return GOOGLE_PAY_SCRIPT_TEMPLATE.substitute(
             # All config values come from provider settings, but escape "<"

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -189,7 +189,9 @@ class Payment(Mock):
         if args or kwargs:
             raise NotImplementedError(f"arguments not supported yet: {args}, {kwargs}")
         payment_from_db = Payment.objects.get(pk=self.pk)
-        refresh_fields = self._meta.get_fields(include_parents=True, include_hidden=True)
+        refresh_fields = self._meta.get_fields(
+            include_parents=True, include_hidden=True
+        )
         if fields is not None:
             refresh_fields = [field for field in refresh_fields if field.name in fields]
         for field in refresh_fields:
@@ -780,8 +782,13 @@ class TestPayuProvider(TestCase):
             self.assertIn("payu-widget", rendered_html)
             self.assertIn("https://example.com/process_url/token", rendered_html)
             self.assertIn("cvv-url='foo_url'", rendered_html)
-            self.assertIn("shop-name='&lt;script&gt; alert(&#x27;foo&#x27;)&lt;/script&gt;'", rendered_html)
-            self.assertIn("</script>", rendered_html)  # Test, that escaping works correctly
+            self.assertIn(
+                "shop-name='&lt;script&gt; alert(&#x27;foo&#x27;)&lt;/script&gt;'",
+                rendered_html,
+            )
+            self.assertIn(
+                "</script>", rendered_html
+            )  # Test, that escaping works correctly
             self.assertIn("customer-language='cs'", rendered_html)
 
     def test_payment_error_form_html_not_escaped(self):
@@ -951,6 +958,23 @@ class TestPayuProvider(TestCase):
         html = form.fields["script"].widget.render("a", "b")
         self.assertIn('"button_radius": 22', html)
 
+    def test_payu_widget_form_google_pay_button_color(self):
+        """Test that a configured button color reaches the Google Pay config
+
+        Google's brand guidelines require the white button on dark backgrounds.
+        """
+        self.set_up_provider(
+            True,
+            True,
+            get_refund_description=lambda payment, amount: "test",
+            google_pay={"merchant_id": "test_merchant_id", "button_color": "white"},
+        )
+        self.payment.token = None
+        form = self.provider.get_form(payment=self.payment)
+        html = form.fields["script"].widget.render("a", "b")
+        self.assertIn('"button_color": "white"', html)
+        self.assertIn("buttonOptions.buttonColor = cfg.button_color", html)
+
     def test_payu_widget_form_google_pay_reinit_guards(self):
         """Test the re-injection guards: skip double init, init without onload"""
         self.set_up_provider(
@@ -965,6 +989,7 @@ class TestPayuProvider(TestCase):
         self.assertIn("container.hasChildNodes()", html)
         self.assertIn("window.google && window.google.payments", html)
         self.assertIn('"button_radius": null', html)
+        self.assertIn('"button_color": null', html)
 
     def test_payu_widget_form_google_pay_sandbox(self):
         """Test that the Google Pay button uses TEST environment on sandbox"""


### PR DESCRIPTION
Google's brand guidelines require the **white** Google Pay button on dark backgrounds; the default (black) button is rejected by their integration review ("The background is dark, requiring a light button theme").

Adds an optional `button_color` key to the `google_pay` config, passed to `createButton` as `buttonColor` (`black`/`white`/`default`), mirroring the existing `button_radius` option.

Usage: `'google_pay': {..., 'button_color': 'white'}`.

Tests: 2 new (configured color reaches the button; default is null), 60 total green on Django 4.2 + 5.2; flake8/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)