### PR TITLE
provider: don't demote a CONFIRMED payment on a later notification

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 
 History
 -------
+Unreleased
+**********
+* ``process_notification``: never demote a ``CONFIRMED`` payment. PayU can
+  deliver duplicate/out-of-order notifications (e.g. a stale ``CANCELED``
+  after ``COMPLETED``); applying one used to clobber a real capture, moving
+  the payment to ``REJECTED``/``ERROR`` while it had actually been paid. The
+  spurious callback is now acked (``200 ok``, so PayU stops retrying) and the
+  ``CONFIRMED`` status is kept. Legitimate refunds are unaffected (they are
+  handled by the dedicated ``refund`` branch). Mirrors the existing
+  ``create_order`` guard added in 2.1.2.
+
 2.4.0 (2026-07-15)
 ******************
 * Google Pay: add an optional ``button_color`` key in the ``google_pay``

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -826,12 +826,22 @@ class PayuProvider(BasicProvider):
                         payment.status == PaymentStatus.CONFIRMED
                         and payment.status != status
                     ):
+                        # A CONFIRMED payment must not be demoted by a later
+                        # notification. PayU can deliver duplicate/out-of-order
+                        # callbacks (e.g. a stale CANCELED arriving after
+                        # COMPLETED); applying one would clobber a real capture.
+                        # Refunds are handled by the "refund" branch above, not
+                        # here, so any non-confirmed status for an already
+                        # confirmed payment is spurious. Ack it (200) so PayU
+                        # stops retrying, but keep the CONFIRMED state.
                         logger.error(
-                            "Suspicious status change of payment %s: %s -> %s",
+                            "Suspicious status change of payment %s: %s -> %s; "
+                            "keeping CONFIRMED",
                             payment.id,
                             payment.status,
                             status,
                         )
+                        return HttpResponse("ok", status=200)
                     payment.change_status(status)
                     return HttpResponse("ok", status=200)
         return HttpResponse("not ok", status=500)

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -1288,6 +1288,47 @@ class TestPayuProvider(TestCase):
         self.assertEqual(self.payment.status, PaymentStatus.REJECTED)
         self.assertEqual(self.payment.captured_amount, Decimal("0"))
 
+    def test_process_notification_does_not_demote_confirmed(self):
+        """A stale CANCELED notification must not demote a CONFIRMED payment.
+
+        PayU can deliver duplicate/out-of-order callbacks; a CANCELED arriving
+        after COMPLETED must not clobber a real capture. The notification is
+        acked (200 "ok") so PayU stops retrying, but the status stays CONFIRMED.
+        """
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        self.payment.transaction_id = "123"
+        self.payment.change_status(PaymentStatus.CONFIRMED)
+        self.payment.save()
+        mocked_request = MagicMock()
+        mocked_request.body = json.dumps(
+            {
+                "order": dict(
+                    self.provider.get_processor(self.payment).as_json(),
+                    orderId=self.payment.transaction_id,
+                    orderCreateDate="2012-12-31T12:00:00",
+                    status="CANCELED",
+                )
+            }
+        ).encode("utf8")
+        mocked_request.META = {
+            "CONTENT_TYPE": "application/json",
+            "HTTP_OPENPAYU_SIGNATURE": "signature=f376048898aa0c629d1f64317ce13736;algorithm=MD5",
+        }
+        mocked_request.status_code = 200
+
+        ret_val = self.provider.process_data(
+            payment=self.payment, request=mocked_request
+        )
+
+        self.assertEqual(ret_val.__class__.__name__, "HttpResponse")
+        self.assertEqual(ret_val.status_code, 200)
+        self.assertEqual(ret_val.content, b"ok")
+        self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
+        self.payment.refresh_from_db()
+        self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
+
     def test_process_notification_refund(self):
         """Test processing PayU refund notification"""
         self.payment.captured_amount = self.payment.total


### PR DESCRIPTION
## Problem

PayU can deliver duplicate or out-of-order order notifications — for example a stale `CANCELED` arriving *after* `COMPLETED`. `process_notification` already detected this case (the `"Suspicious status change of payment ..."` log) but then called `change_status(status)` anyway, demoting a payment that had actually been captured. The payment ended up `REJECTED`/`ERROR` despite the money having been taken, silently desyncing any downstream "paid" state derived from the payment status.

## Fix

When the payment is already `CONFIRMED` and an incoming notification carries a different (non-confirmed) status, ack it (`200 ok`, so PayU stops retrying) and keep the `CONFIRMED` state instead of applying the demotion.

Genuine refunds are unaffected — they are handled by the dedicated `refund` branch earlier in `process_notification`, not by this status-map path. This mirrors the existing `create_order` guard added in 2.1.2 ("don't demote a CONFIRMED payment to ERROR on duplicate create_order").

## Testing

- New regression test `test_process_notification_does_not_demote_confirmed`: confirms a payment, then delivers a stale `CANCELED` notification and asserts the status stays `CONFIRMED` with a `200 ok` response. Verified it fails without the fix (`rejected`) and passes with it.
- Existing `test_process_notification_cancelled` still passes — a `CANCELED` on a *non-confirmed* payment is still a legitimate demotion to `REJECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)