### PR TITLE
Invalidate dead renew tokens; store rejection transaction detail

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,19 @@
 
 History
 -------
+Unreleased
+**********
+* permanent token errors (PayU ``INVALID_TOKEN``) now invalidate the stored
+  renew token via the host's optional ``payment.invalidate_renew_token()``
+  hook - renewal tasks stop retrying a token that can never work again and
+  interactive users get a fresh card widget instead of a guaranteed
+  failure. Retryable declines (insufficient funds etc.) are unaffected.
+* rejected payments store the PayU transaction detail (``paymentFlow`` +
+  card response codes, e.g. "114 - 3ds authentication error") in
+  ``extra_data["rejection_transaction"]`` - the CANCELED notification
+  itself carries no reason, so this is the only durable record of why a
+  payment was declined.
+
 2.5.0 (2026-07-21)
 ******************
 * replace the stray debug ``print`` in the refund notification path and the

--- a/payments_payu/provider.py
+++ b/payments_payu/provider.py
@@ -44,6 +44,10 @@ CURRENCY_SUB_UNIT = {
 
 CENTS = Decimal("0.01")
 
+# PayU error codeLiterals that mean the stored card token can never work
+# again (as opposed to retryable declines like insufficient funds).
+PERMANENT_TOKEN_ERROR_LITERALS = frozenset({"INVALID_TOKEN"})
+
 GOOGLE_PAY_ALLOWED_AUTH_METHODS = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
 GOOGLE_PAY_ALLOWED_CARD_NETWORKS = ["MASTERCARD", "VISA"]
 
@@ -916,6 +920,30 @@ class PayuProvider(BasicProvider):
             )
             return ""
         payment.change_status(PaymentStatus.ERROR)
+        if (
+            isinstance(response_status, dict)
+            and response_status.get("codeLiteral") in PERMANENT_TOKEN_ERROR_LITERALS
+        ):
+            # The stored card token is permanently dead (e.g. deactivated at
+            # PayU) - retrying it can never succeed. Drop it so renewal tasks
+            # stop selecting the account and interactive users get a fresh
+            # card widget instead of a guaranteed failure.
+            invalidate = getattr(payment, "invalidate_renew_token", None)
+            if callable(invalidate):
+                invalidate()
+                logger.info(
+                    "Invalidated the renew token of payment %s after %s",
+                    payment.pk,
+                    response_status.get("codeLiteral"),
+                )
+            else:
+                logger.warning(
+                    "Payment %s failed with the permanent token error %s, but the "
+                    "payment model does not implement invalidate_renew_token() - "
+                    "the dead token will keep being retried",
+                    payment.pk,
+                    response_status.get("codeLiteral"),
+                )
         try:
             raise PayuApiError(response_dict)
         except PayuApiError:
@@ -1070,9 +1098,45 @@ class PayuProvider(BasicProvider):
                             status,
                         )
                         return HttpResponse("ok", status=200)
+                    if status == PaymentStatus.REJECTED:
+                        self._store_rejection_transaction(payment)
                     payment.change_status(status)
                     return HttpResponse("ok", status=200)
         return HttpResponse("not ok", status=500)
+
+    def _store_rejection_transaction(self, payment):
+        """Store the PayU transaction detail of a rejected order.
+
+        The CANCELED notification carries no reason - the transaction detail
+        (paymentFlow + card response codes, e.g. "114 - 3ds authentication
+        error") is the only record of why the payment was declined, so keep
+        it in extra_data for diagnostics. Best-effort: a fetch failure must
+        never break the notification ack.
+        """
+        try:
+            response = requests.get(
+                f"{self.payu_api_orders_url}{payment.transaction_id}/transactions",
+                headers=self.get_token_headers(),
+            )
+            transactions = json.loads(response.text).get("transactions") or []
+        except (requests.RequestException, ValueError) as e:
+            logger.warning(
+                "Could not fetch the transaction detail of rejected payment %s: %s",
+                payment.pk,
+                e,
+            )
+            return
+        if not transactions:
+            return
+        add_extra_data(
+            payment,
+            {
+                "rejection_transaction": {
+                    "paymentFlow": transactions[0].get("paymentFlow"),
+                    "card": transactions[0].get("card"),
+                }
+            },
+        )
 
     def process_data(self, payment, request, *args, **kwargs):
         self.request = request

--- a/tests/test_payu.py
+++ b/tests/test_payu.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from decimal import Decimal
 from unittest import TestCase
 
+import requests
 from django.template import Context, Template
 from mock import MagicMock, Mock, patch
 from payments import FraudStatus, PaymentStatus, PurchasedItem, RedirectNeeded
@@ -185,6 +186,12 @@ class Payment(Mock):
 
     def get_renew_token(self):
         return self.token
+
+    renew_token_invalidated = False
+
+    def invalidate_renew_token(self):
+        self.renew_token_invalidated = True
+        self.token = None
 
     def set_renew_token(
         self,
@@ -3061,6 +3068,173 @@ class TestPayuProvider(TestCase):
         first_buyer = dict(processor.buyer)
         processor.set_buyer_data("Other", "Person", "other@example.com", None, "en")
         self.assertEqual(processor.buyer, first_buyer)
+
+    def _post_widget_token(self, response_body):
+        self.payment.token = None
+        mocked_request = MagicMock()
+        mocked_request.POST = {"value": "CARD_TOKEN"}
+        mocked_request.META = {}
+        with patch("requests.post") as mocked_post:
+            post = MagicMock()
+            post.text = json.dumps(response_body)
+            post.status_code = 400
+            mocked_post.return_value = post
+            return self.provider.process_data(
+                payment=self.payment, request=mocked_request
+            )
+
+    def test_create_order_invalid_token_invalidates_renew_token(self):
+        """A permanent INVALID_TOKEN error drops the stored renew token.
+
+        Retrying a token PayU no longer knows can never succeed - the renewal
+        task must stop selecting the account and interactive users must get a
+        fresh card widget instead of a guaranteed failure.
+        """
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        response = self._post_widget_token(
+            {
+                "status": {
+                    "statusCode": "ERROR_VALUE_INVALID",
+                    "code": "8342",
+                    "codeLiteral": "INVALID_TOKEN",
+                    "statusDesc": "Invalid or expired token",
+                }
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+        self.assertIs(self.payment.renew_token_invalidated, True)
+
+    def test_create_order_business_error_keeps_renew_token(self):
+        """A non-token error (e.g. antifraud) must not drop the renew token."""
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        self._post_widget_token(
+            {"status": {"statusCode": "BUSINESS_ERROR", "codeLiteral": "Foo code"}}
+        )
+        self.assertIs(self.payment.renew_token_invalidated, False)
+
+    def test_create_order_invalid_token_without_host_hook(self):
+        """A host Payment without invalidate_renew_token only gets a warning."""
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        with patch.object(Payment, "invalidate_renew_token", None):
+            with self.assertLogs("payments_payu.provider", level="WARNING") as logs:
+                self._post_widget_token(
+                    {
+                        "status": {
+                            "statusCode": "ERROR_VALUE_INVALID",
+                            "codeLiteral": "INVALID_TOKEN",
+                        }
+                    }
+                )
+        self.assertTrue(
+            any(
+                "does not implement invalidate_renew_token" in line
+                for line in logs.output
+            ),
+            logs.output,
+        )
+        self.assertEqual(self.payment.status, PaymentStatus.ERROR)
+
+    def _notify_canceled(self):
+        mocked_request = MagicMock()
+        mocked_request.body = json.dumps(
+            {
+                "order": dict(
+                    self.provider.get_processor(self.payment).as_json(),
+                    orderId=self.payment.transaction_id,
+                    orderCreateDate="2012-12-31T12:00:00",
+                    status="CANCELED",
+                )
+            }
+        ).encode("utf8")
+        signature = hashlib.md5(
+            mocked_request.body + SECOND_KEY.encode("utf8")
+        ).hexdigest()
+        mocked_request.META = {
+            "CONTENT_TYPE": "application/json",
+            "HTTP_OPENPAYU_SIGNATURE": "signature={};algorithm=MD5".format(signature),
+        }
+        mocked_request.status_code = 200
+        return self.provider.process_data(payment=self.payment, request=mocked_request)
+
+    def test_process_notification_rejected_stores_transaction_detail(self):
+        """A rejection stores the PayU transaction detail for diagnostics.
+
+        The CANCELED notification carries no reason; the transaction detail
+        (paymentFlow + card response codes) is the only record of why the
+        payment was declined.
+        """
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        self.payment.transaction_id = "1234"
+        self.payment.save()
+        with patch("requests.get") as mocked_get:
+            get = MagicMock()
+            get.text = json.dumps(
+                {
+                    "transactions": [
+                        {
+                            "payMethod": {"value": "c"},
+                            "paymentFlow": "GOOGLE_PAY",
+                            "card": {
+                                "cardData": {
+                                    "cardResponseCodeDesc": "114 - 3ds authentication error (global)"
+                                }
+                            },
+                        }
+                    ]
+                }
+            )
+            get.status_code = 200
+            mocked_get.return_value = get
+            ret_val = self._notify_canceled()
+        self.assertEqual(ret_val.content, b"ok")
+        self.assertEqual(self.payment.status, PaymentStatus.REJECTED)
+        detail = json.loads(self.payment.extra_data)["rejection_transaction"]
+        self.assertEqual(detail["paymentFlow"], "GOOGLE_PAY")
+        self.assertEqual(
+            detail["card"]["cardData"]["cardResponseCodeDesc"],
+            "114 - 3ds authentication error (global)",
+        )
+
+    def test_process_notification_rejected_with_no_transactions(self):
+        """An empty transaction list simply stores no rejection detail."""
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        self.payment.transaction_id = "1234"
+        self.payment.save()
+        with patch("requests.get") as mocked_get:
+            get = MagicMock()
+            get.text = json.dumps({"transactions": []})
+            get.status_code = 200
+            mocked_get.return_value = get
+            ret_val = self._notify_canceled()
+        self.assertEqual(ret_val.content, b"ok")
+        self.assertEqual(self.payment.status, PaymentStatus.REJECTED)
+        self.assertNotIn("rejection_transaction", json.loads(self.payment.extra_data))
+
+    def test_process_notification_rejected_survives_fetch_failure(self):
+        """A failing transaction-detail fetch must not break the rejection ack."""
+        self.set_up_provider(
+            True, True, get_refund_description=lambda payment, amount: "test"
+        )
+        self.payment.transaction_id = "1234"
+        self.payment.save()
+        with patch("requests.get") as mocked_get:
+            mocked_get.side_effect = requests.ConnectionError("boom")
+            with self.assertLogs("payments_payu.provider", level="WARNING"):
+                ret_val = self._notify_canceled()
+        self.assertEqual(ret_val.content, b"ok")
+        self.assertEqual(self.payment.status, PaymentStatus.REJECTED)
+        self.assertNotIn("rejection_transaction", json.loads(self.payment.extra_data))
 
     @contextlib.contextmanager
     def _patch_refund(


### PR DESCRIPTION
Two production findings from the wallet-launch monitoring on BlenderKit:

## 1. Permanent token errors kept being retried
`INVALID_TOKEN` (stored card token deactivated at PayU) can never succeed, yet:
- the renewal task burned its whole retry ladder on it (observed hourly), and
- interactive one-click users were short-circuited into the same dead token (observed: identical failures 6 minutes apart).

`create_order` now calls the host's **optional** `payment.invalidate_renew_token()` hook on permanent token errors (currently `INVALID_TOKEN` only). Hosts that don't implement the hook just get a warning log. Retryable declines (insufficient funds, 3DS failures, …) are untouched — anything with a chance of success keeps its full retry schedule.

## 2. Rejections stored no reason
The CANCELED notification carries no decline reason; diagnosing failures meant querying PayU's transactions API per order by hand. On rejection the provider now stores the transaction detail (`paymentFlow` + card response codes, e.g. `114 - 3ds authentication error`) into `extra_data["rejection_transaction"]`, best-effort (a fetch failure never breaks the notification ack).

Tests: 6 new, provider coverage stays at 100% lines + branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)